### PR TITLE
feat: move pen tests to cronjob

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   schedule:
-    - cron: "0 11 * * 0" # 3 AM PST = 12 PM UDT, runs sundays
+    - cron: "0 11 * * 0" # 3 AM PST = 12 PM UDT, Sundays
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,10 +39,6 @@ jobs:
           parameters:
             -p ZONE=test -p PROMOTE=${{ github.repository }}/${{ matrix.name }}:test
             -p NAME=${{ github.event.repository.name }} ${{ matrix.parameters }}
-          penetration_test: true
-          penetration_test_artifact: ${{ matrix.name }}
-          penetration_test_issue: ${{ matrix.name }}
-          penetration_test_token: ${{ secrets.GITHUB_TOKEN }}
           verification_path: ${{ matrix.verification_path }}
 
   deploys-prod:
@@ -72,7 +68,6 @@ jobs:
           parameters:
             -p ZONE=prod -p PROMOTE=${{ github.repository }}/${{ matrix.name }}:test
             -p NAME=${{ github.event.repository.name }} ${{ matrix.parameters }}
-          penetration_test: false
           verification_path: ${{ matrix.verification_path }}
 
   image-promotions:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -24,7 +24,7 @@ jobs:
           - name: backend
             file: backend/openshift.deploy.yml
             overwrite: true
-            verification_path: /api
+            verification_path: /health
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true
@@ -53,7 +53,7 @@ jobs:
           - name: backend
             file: backend/openshift.deploy.yml
             overwrite: true
-            verification_path: /api
+            verification_path: /health
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true

--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -1,0 +1,31 @@
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 11 * * 6" # 3 AM PST = 12 PM UDT, Saturdays
+  
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zap_scan:
+    runs-on: ubuntu-latest
+    name: Penetration Tests
+    env:
+      DOMAIN: apps.silver.devops.gov.bc.ca
+      PREFIX: ${{ github.event.repository.name }}-test
+    strategy:
+      matrix:
+        name: [backend, frontend]
+    steps:
+      - name: ZAP Scan
+        uses: zaproxy/action-full-scan@v0.7.0
+        with:
+          allow_issue_writing: true
+          artifact_name: "zap_${{ inputs.name }}"
+          cmd_options: "-a"
+          issue_title: "ZAP: ${{ inputs.name }}"
+          target: https://${{ env.PREFIX }}-${{ inputs.name }}.${{ env.DOMAIN }}

--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -1,9 +1,7 @@
+name: Penetration Tests
+
 on:
-  pull_request:
-    branches: [main]
-  schedule:
-    - cron: "0 11 * * 6" # 3 AM PST = 12 PM UDT, Saturdays
-  
+  schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
   workflow_dispatch:
 
 concurrency:
@@ -25,7 +23,7 @@ jobs:
         uses: zaproxy/action-full-scan@v0.7.0
         with:
           allow_issue_writing: true
-          artifact_name: "zap_${{ inputs.name }}"
+          artifact_name: "zap_${{ matrix.name }}"
           cmd_options: "-a"
-          issue_title: "ZAP: ${{ inputs.name }}"
-          target: https://${{ env.PREFIX }}-${{ inputs.name }}.${{ env.DOMAIN }}
+          issue_title: "ZAP: ${{ matrix.name }}"
+          target: https://${{ env.PREFIX }}-${{ matrix.name }}.${{ env.DOMAIN }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,8 +1,8 @@
 name: PR
 
 on:
-  # pull_request:
-  #   branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,8 +1,8 @@
 name: PR
 
 on:
-  pull_request:
-    branches: [main]
+  # pull_request:
+  #   branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
- remove penetration tests from main merge
- create weekly cronjob for penetration tests
- ensure issues are written with results
- fix to main merge verification paths

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-24-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-24-backend.apps.silver.devops.gov.bc.ca)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge-main.yml)