### PR TITLE
added the bceId naming logic

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,7 +1,7 @@
 VITE_MAIN_VERSION = v1.0.0
-VITE_USER_POOLS_ID= ca-central-1_FxagSNQa7
-VITE_USER_POOLS_WEB_CLIENT_ID= 3g6n2ha1loi4kp1jhaq359vrvb
+VITE_USER_POOLS_ID= ca-central-1_t2HSZBHur
+VITE_USER_POOLS_WEB_CLIENT_ID= 70a2am185rie10r78b0ugcs1mm
 VITE_CHES_FROM_EMAIL = resultsaccess@gov.bc.ca
 VITE_CHES_ADMIN_EMAIL = resultsaccess@gov.bc.ca
 VITE_BACK_URL = http://localhost:5000
-VITE_ZONE = DEV
+VITE_ZONE = prod

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -86,12 +86,23 @@ async function refreshToken (): Promise<FamLoginUser | undefined> {
 function parseToken(authToken: CognitoUserSession): FamLoginUser {
   const decodedIdToken = authToken.getIdToken().decodePayload();
   const decodedAccessToken = authToken.getAccessToken().decodePayload();
-  // console.log("User token decoded:")
-  // console.log(decodedIdToken)
+  console.log("User token decoded:")
+  console.log(decodedIdToken)
   // Extract the first name and last name from the displayName and remove unwanted part
   const displayName = decodedIdToken['custom:idp_display_name'];
-  const [lastName, firstName] = displayName.split(', ');
-  const sanitizedFirstName = firstName.split(' ')[0].trim(); // Remove unwanted part
+  const hasComma = displayName.includes(',');
+
+  let [lastName, firstName] = hasComma
+    ? displayName.split(', ')
+    : displayName.split(' ');
+
+  if (!hasComma) {
+    // In case of "First Last" format, swap first and last names
+    [lastName, firstName] = [firstName, lastName];
+  }
+
+  const sanitizedFirstName = hasComma ? firstName.split(' ')[0].trim() : firstName;
+
   const famLoginUser = {
     userName: decodedIdToken['custom:idp_username'],
     displayName,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Fixed the bug which prevented bceId users from logging in to the application

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Docker Compose Locally


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-72-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-72-backend.apps.silver.devops.gov.bc.ca)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge-main.yml)