### PR TITLE
chore(ci): deploymentconfig deprecation

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -10,9 +10,6 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: IMAGE_TAG
-    description: Image tag to use
-    value: latest
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
   - name: CPU_REQUEST
@@ -40,7 +37,7 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: ORG_NAME
+  - name: ORG
     description: Organization name, e.g. bcgov
     value: bcgov
   - name: PROMOTE
@@ -99,22 +96,6 @@ objects:
             - podSelector: {}
       policyTypes:
         - Ingress
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: "${NAME}-${ZONE}"
-      name: "${NAME}-${ZONE}-${COMPONENT}"
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: "${IMAGE_TAG}"
-          from:
-            kind: DockerImage
-            name: "${REGISTRY}/${PROMOTE}"
-          referencePolicy:
-            type: Local
   - kind: Deployment
     apiVersion: apps/v1
     metadata:
@@ -135,7 +116,7 @@ objects:
             deployment: "${NAME}-${ZONE}-${COMPONENT}"
         spec:
           containers:
-            - image: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               imagePullPolicy: Always
               name: "${NAME}"
               env:

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -66,6 +66,10 @@ parameters:
   - name: S3_SECRETKEY
     description: Secret key for S3
     required: true
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
@@ -149,6 +153,8 @@ objects:
                   value: ${S3_ENDPOINT}
                 - name: S3_SECRETKEY
                   value: ${S3_SECRETKEY}
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: 5000
                   protocol: TCP

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -111,33 +111,24 @@ objects:
             name: "${REGISTRY}/${PROMOTE}"
           referencePolicy:
             type: Local
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       labels:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - "${NAME}"
-            from:
-              kind: ImageStreamTag
-              name: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        matchLabels:
+          deployment: "${NAME}-${ZONE}-${COMPONENT}"
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
             app: "${NAME}-${ZONE}"
-            deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+            deployment: "${NAME}-${ZONE}-${COMPONENT}"
         spec:
           containers:
             - image: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
@@ -201,7 +192,7 @@ objects:
           port: 80
           targetPort: 5000
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        deployment: "${NAME}-${ZONE}-${COMPONENT}"
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:
@@ -226,7 +217,7 @@ objects:
     spec:
       scaleTargetRef:
         apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        kind: Deployment
         name: "${NAME}-${ZONE}-${COMPONENT}"
       minReplicas: "${{MIN_REPLICAS}}"
       maxReplicas: "${{MAX_REPLICAS}}"

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -10,9 +10,6 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: IMAGE_TAG
-    description: Image tag to use
-    value: latest
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
   - name: CPU_REQUEST
@@ -32,6 +29,9 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
+  - name: ORG
+    description: Organization name, e.g. bcgov
+    value: bcgov
   - name: PROMOTE
     description: Image (namespace/name:tag) to promote/import
     value: bcgov/nr-results-exam/frontend:prod
@@ -49,22 +49,6 @@ parameters:
     from: "[a-zA-Z0-9]{32}"
     generate: expression
 objects:
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: "${NAME}-${ZONE}"
-      name: "${NAME}-${ZONE}-${COMPONENT}"
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: "${IMAGE_TAG}"
-          from:
-            kind: DockerImage
-            name: "${REGISTRY}/${PROMOTE}"
-          referencePolicy:
-            type: Local
   - kind: Deployment
     apiVersion: apps/v1
     metadata:
@@ -85,7 +69,7 @@ objects:
             deployment: "${NAME}-${ZONE}-${COMPONENT}"
         spec:
           containers:
-            - image: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               securityContext:
                 capabilities:
                   add: ["NET_BIND_SERVICE"]

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -61,32 +61,24 @@ objects:
             name: "${REGISTRY}/${PROMOTE}"
           referencePolicy:
             type: Local
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       labels:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames: ["${NAME}"]
-            from:
-              kind: ImageStreamTag
-              name: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        matchLabels:
+          deployment: "${NAME}-${ZONE}-${COMPONENT}"
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
             app: "${NAME}-${ZONE}"
-            deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+            deployment: "${NAME}-${ZONE}-${COMPONENT}"
         spec:
           containers:
             - image: "${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}"
@@ -149,7 +141,7 @@ objects:
           port: 80
           targetPort: 3000
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        deployment: "${NAME}-${ZONE}-${COMPONENT}"
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:
@@ -174,7 +166,7 @@ objects:
     spec:
       scaleTargetRef:
         apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        kind: Deployment
         name: "${NAME}-${ZONE}-${COMPONENT}"
       minReplicas: "${{MIN_REPLICAS}}"
       maxReplicas: "${{MAX_REPLICAS}}"

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -44,6 +44,10 @@ parameters:
     value: DEV
   - name: S3_SECRETKEY
     description: Dummy param to satisfy workflow
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - apiVersion: v1
     kind: ImageStream
@@ -98,6 +102,8 @@ objects:
                   value: "${VITE_QUESTIONS_API_KEY}"
                 - name: VITE_ZONE
                   value: "${ZONE}"
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: 3000
                   protocol: TCP


### PR DESCRIPTION
Replaces deprecated Deployment Configs with Deployments. Also removes image streams and uses a randomly generated envar to ensure consistent rollouts.

Unfortunately there will be some downtime when this deploys.

Steps:
- Delete deployment configs and services for TEST database and backend
- Delete deployment configs and services for PROD database and backend
- Merge this PR
- Let deployments to TEST and PROD complete

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-210-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-210-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)