### PR TITLE
chore(ci): add timeouts to pr-open and merge workflows

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -31,6 +31,7 @@ jobs:
     name: Init (TEST)
     needs: vars
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
       - uses: bcgov/action-deployer-openshift@v3.1.0
         with:
@@ -49,9 +50,10 @@ jobs:
     name: Deploys (TEST)
     needs: [vars, init-test]
     environment: test
-    runs-on: ubuntu-24.04
     permissions:
       issues: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     strategy:
       matrix:
         name: [backend, frontend]
@@ -72,6 +74,7 @@ jobs:
     name: Init (PROD)
     needs: [vars, deploys-test]
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
       - uses: bcgov/action-deployer-openshift@v3.1.0
         with:
@@ -89,6 +92,7 @@ jobs:
     needs: [vars, init-prod]
     environment: prod
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     strategy:
       matrix:
         name: [backend, frontend]
@@ -108,12 +112,13 @@ jobs:
   image-promotions:
     name: Promote images
     needs: [vars, deploys-prod]
-    runs-on: ubuntu-24.04
     permissions:
       packages: write
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         component: [backend, frontend]
+    timeout-minutes: 1
     steps:
       - uses: shrink/actions-docker-registry-tag@v4
         with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         package: [backend, frontend]
+    timeout-minutes: 10
     steps:
       - uses: bcgov/action-builder-ghcr@v2.3.0
         with:
@@ -31,6 +32,7 @@ jobs:
   init:
     name: Init
     runs-on: ubuntu-24.04
+    timeout-minutes: 1
     steps:
       - uses: bcgov/action-deployer-openshift@v3.1.0
         with:
@@ -50,6 +52,7 @@ jobs:
     name: Deploys
     needs: [builds, init]
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     strategy:
       matrix:
         name: [backend, frontend]


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-278-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-278-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)