### PR TITLE
chore(ci): mod 50 zone numbering for FAM

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -61,6 +61,8 @@ jobs:
         include:
           - name: backend
             verification_path: /health
+          - name: frontend
+            parameters: -p MOD_ZONE=test
     steps:
       - uses: bcgov/action-deployer-openshift@v3.1.0
         with:
@@ -68,7 +70,10 @@ jobs:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
-          parameters: -p ZONE=test -p TAG=${{ needs.vars.outputs.pr }}
+          parameters:
+            -p ZONE=test
+            -p TAG=${{ needs.vars.outputs.pr }}
+            ${{ matrix.parameters }}
           verification_path: ${{ matrix.verification_path }}
 
   init-prod:
@@ -101,6 +106,8 @@ jobs:
         include:
           - name: backend
             verification_path: /health
+          - name: frontend
+            parameters: -p MOD_ZONE=prod
     steps:
       - uses: bcgov/action-deployer-openshift@v3.1.0
         with:
@@ -108,7 +115,10 @@ jobs:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
-          parameters: -p ZONE=prod -p TAG=${{ needs.vars.outputs.pr }}
+          parameters:
+            -p ZONE=prod
+            -p TAG=${{ needs.vars.outputs.pr }}
+            ${{ matrix.parameters }}
           verification_path: ${{ matrix.verification_path }}
 
   image-promotions:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -60,7 +60,7 @@ jobs:
           - name: backend
             verification_path: /health
           - name: frontend
-            parameters: -p MOD_ZONE=$(( github.event.number % 50))
+            parameters: -p MOD_ZONE=$(( ${{ github.event.number }} % 50))
     steps:
       - uses: bcgov/action-deployer-openshift@v3.1.0
         with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -59,6 +59,8 @@ jobs:
         include:
           - name: backend
             verification_path: /health
+          - name: frontend
+            parameters: -p MOD_ZONE=$(( github.event.number % 50))
     steps:
       - uses: bcgov/action-deployer-openshift@v3.1.0
         with:
@@ -66,7 +68,10 @@ jobs:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
-          parameters: -p ZONE=${{ github.event.number }} -p TAG=${{ github.event.number }}
+          parameters:
+            -p ZONE=${{ github.event.number }}
+            -p TAG=${{ github.event.number }}
+            ${{ matrix.parameters }}
           triggers: ('backend/' 'common/' 'frontend/')
           verification_path: ${{ matrix.verification_path }}
 

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -15,7 +15,7 @@ jobs:
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@v0.8.3
     with:
       markdown_links: |
-        - [Frontend](https://${{ github.event.repository.name }}-$(( github.event.number % 50 ))-frontend.apps.silver.devops.gov.bc.ca)
+        - [Frontend](https://${{ github.event.repository.name }}-$((${{ github.event.number }} % 50))-frontend.apps.silver.devops.gov.bc.ca)
         - [Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca/api)
 
   results:

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -15,7 +15,7 @@ jobs:
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@v0.8.3
     with:
       markdown_links: |
-        - [Frontend](https://$((${{ github.event.repository.name }} % 50))-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca)
+        - [Frontend](https://${{ github.event.repository.name }}-$(( github.event.number % 50 ))-frontend.apps.silver.devops.gov.bc.ca)
         - [Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca/api)
 
   results:

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -15,7 +15,7 @@ jobs:
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@v0.8.3
     with:
       markdown_links: |
-        - [Frontend](https://${{ github.event.repository.name }}-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca)
+        - [Frontend](https://$((${{ github.event.repository.name }} % 50))-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca)
         - [Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca/api)
 
   results:

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -8,18 +8,26 @@ concurrency:
   group: ${{ github.workflow }}-edit-${{ github.event.number }}
   cancel-in-progress: true
 
-env:
-  mod_tag: $(( ${{ github.event.number }} % 50 ))
-
 jobs:
+  fam-route:
+    name: Get Route Tag for FAM in PRs
+    outputs:
+      fam-route: ${{ steps.fam-route.outputs.fam-route }}
+    runs-on: ubuntu-24.04
+    steps:
+      - id: fam-route
+        run: echo "fam-route=$(( ${{ github.event.number }} % 50 ))" >> $GITHUB_OUTPUT
+
   validate:
     name: Validate PR
-    if: (! github.event.pull_request.draft)
+    needs: [fam-route]
+    permissions:
+      pull-requests: write
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@v0.8.3
     with:
       markdown_links: |
-        - [Frontend](https://${{ github.event.repository.name }}-${{ env.mod_tag }}-frontend.apps.silver.devops.gov.bc.ca)
-        - [Backend](https://${{ github.event.repository.name }}-${{ env.mod_tag }}-frontend.apps.silver.devops.gov.bc.ca/api)
+        - [Frontend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.fam-route }}-frontend.apps.silver.devops.gov.bc.ca)
+        - [Backend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.fam-route }}-frontend.apps.silver.devops.gov.bc.ca/api)
 
   results:
     name: Validate Results

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-edit-${{ github.event.number }}
   cancel-in-progress: true
 
+env:
+  mod_tag: $(( ${{ github.event.number }} % 50 ))
+
 jobs:
   validate:
     name: Validate PR
@@ -15,8 +18,8 @@ jobs:
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@v0.8.3
     with:
       markdown_links: |
-        - [Frontend](https://${{ github.event.repository.name }}-$((${{ github.event.number }} % 50))-frontend.apps.silver.devops.gov.bc.ca)
-        - [Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca/api)
+        - [Frontend](https://${{ github.event.repository.name }}-${{ env.mod_tag }}-frontend.apps.silver.devops.gov.bc.ca)
+        - [Backend](https://${{ github.event.repository.name }}-${{ env.mod_tag }}-frontend.apps.silver.devops.gov.bc.ca/api)
 
   results:
     name: Validate Results

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -41,6 +41,9 @@ parameters:
   - name: LOG_LEVEL
     description: Caddy logging level DEBUG, INFO, WARN, ERROR, PANIC, and FATAL (https://github.com/caddyserver/caddy/blob/master/logging.go)
     value: "info"
+  - name: VITE_AWS_DOMAIN
+    description: FAM on AWS domain
+    value: https://prod-fam-user-pool-domain.auth.ca-central-1.amazoncognito.com
   - name: VITE_ZONE
     value: DEV
   - name: RANDOM_EXPRESSION
@@ -77,6 +80,8 @@ objects:
               env:
                 - name: LOG_LEVEL
                   value: "${LOG_LEVEL}"
+                - name: VITE_AWS_DOMAIN
+                  value: ${VITE_AWS_DOMAIN}
                 - name: VITE_BACKEND_URL
                   value: "https://${NAME}-${ZONE}-backend.${DOMAIN}:443"
                 - name: VITE_USER_POOLS_WEB_CLIENT_ID

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -8,7 +8,10 @@ parameters:
     description: Component name
     value: frontend
   - name: ZONE
-    description: Deployment zone, e.g. pr-### or prod
+    description: Deployment zone, e.g. pr-###, test or prod
+    required: true
+  - name: MOD_ZONE
+    description: Deployment zone, modified for PRs,e.g. pr-### % 50, test or prod
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -141,7 +144,7 @@ objects:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
-      host: "${NAME}-${ZONE}-${COMPONENT}.${DOMAIN}"
+      host: "${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}"
       port:
         targetPort: 3000-tcp
       to:


### PR DESCRIPTION
Load PR numbers mod 50, so reuse a set of 50 PR numbers.  This is to work with FAM's allowlist.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam--frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam--frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)