### PR TITLE
chore(ci): move var into openshift secret

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -44,6 +44,7 @@ jobs:
             -p ZONE=test
             -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
+            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
   deploys-test:
     name: Deploys (TEST)
@@ -60,9 +61,7 @@ jobs:
           - name: backend
             verification_path: /health
           - name: frontend
-            parameters:
-              -p MOD_ZONE=test
-              -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
+            parameters: -p MOD_ZONE=test
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -93,6 +92,7 @@ jobs:
             -p ZONE=prod
             -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
+            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
   deploys-prod:
     name: Deploys (PROD)
@@ -107,9 +107,7 @@ jobs:
           - name: backend
             verification_path: /health
           - name: frontend
-            parameters:
-              -p MOD_ZONE=prod
-              -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
+            parameters: -p MOD_ZONE=prod
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -44,6 +44,7 @@ jobs:
             -p ZONE=${{ github.event.number }}
             -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
+            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
           triggers: ('backend/' 'common/' 'frontend/')
 
   deploys:
@@ -58,9 +59,7 @@ jobs:
           - name: backend
             verification_path: /health
           - name: frontend
-            parameters:
-              -p MOD_ZONE=$(( ${{ github.event.number }} % 50))
-              -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
+            parameters: -p MOD_ZONE=$(( ${{ github.event.number }} % 50))
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -11,6 +11,8 @@ parameters:
     required: true
   - name: S3_SECRETKEY
     required: true
+  - name: VITE_USER_POOLS_WEB_CLIENT_ID
+    required: true
 objects:
   - apiVersion: v1
     kind: Secret
@@ -21,6 +23,14 @@ objects:
     stringData:
       ches-client-secret: ${CHE_CLIENT_SECRET}
       s3-secretkey: ${S3_SECRETKEY}
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${REPO}-${ZONE}-frontend
+      labels:
+        app: ${REPO}-${ZONE}
+    stringData:
+      vite-user-pools-web-client-id: ${VITE_USER_POOLS_WEB_CLIENT_ID}
   - apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -89,6 +89,10 @@ objects:
                 - name: VITE_BACKEND_URL
                   value: "https://${NAME}-${ZONE}-backend.${DOMAIN}:443"
                 - name: VITE_USER_POOLS_WEB_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${NAME}-${ZONE}-frontend
+                      key: vite-user-pools-web-client-id
                   value: ${VITE_USER_POOLS_WEB_CLIENT_ID}
                 - name: VITE_USER_POOLS_ID
                   value: ${VITE_USER_POOLS_ID}


### PR DESCRIPTION
This adds a secret for one frontend variable.  It shouldn't be necessary, but I'm troubleshooting to correct an incorrect value.  :/

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam--frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam--frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)