### PR TITLE
chore(ci): remove unused param after deployer update

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -59,7 +59,6 @@ jobs:
         name: [backend, frontend]
         include:
           - name: backend
-            verification_path: /health
           - name: frontend
             parameters: -p MOD_ZONE=test
     steps:
@@ -73,7 +72,6 @@ jobs:
             -p ZONE=test
             -p TAG=${{ needs.vars.outputs.pr }}
             ${{ matrix.parameters }}
-          verification_path: ${{ matrix.verification_path }}
 
   init-prod:
     name: Init (PROD)
@@ -105,7 +103,6 @@ jobs:
         name: [backend, frontend]
         include:
           - name: backend
-            verification_path: /health
           - name: frontend
             parameters: -p MOD_ZONE=prod
     steps:
@@ -119,7 +116,6 @@ jobs:
             -p ZONE=prod
             -p TAG=${{ needs.vars.outputs.pr }}
             ${{ matrix.parameters }}
-          verification_path: ${{ matrix.verification_path }}
 
   image-promotions:
     name: Promote images

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -57,7 +57,6 @@ jobs:
         name: [backend, frontend]
         include:
           - name: backend
-            verification_path: /health
           - name: frontend
             parameters: -p MOD_ZONE=$(( ${{ github.event.number }} % 50))
     steps:
@@ -72,7 +71,6 @@ jobs:
             -p TAG=${{ github.event.number }}
             ${{ matrix.parameters }}
           triggers: ('backend/' 'common/' 'frontend/')
-          verification_path: ${{ matrix.verification_path }}
 
   results:
     name: PR Results


### PR DESCRIPTION
Removing this stale parameter will clean up warnings on our workflows.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam--frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam--frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)