### PR TITLE
fix(frontend): frontend lint errors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,7 +31,7 @@ const privateRoutes: RouteObject[] = [
       { path: "/", element: <Navigate to="/dashboard" /> },
       {
         path: "/dashboard",
-        element: <SideLayout pageContent={<Dashboard />} />,
+        element: <SideLayout pageContent={<Dashboard />} />
       },
       { path: "/testA", element: <SideLayout pageContent={<TestA />} /> },
       { path: "/testB", element: <SideLayout pageContent={<TestB />} /> },

--- a/frontend/src/components/AvatarImage/index.tsx
+++ b/frontend/src/components/AvatarImage/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import './AvatarImage.scss';
 
 type Size = 'small' | 'large';

--- a/frontend/src/components/BCHeader/index.tsx
+++ b/frontend/src/components/BCHeader/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, NavLink } from "react-router-dom";
 import { useThemePreference } from "../../utils/ThemePreference";
 import { toggleTheme } from "../../utils/ThemeFunction";
 import {
@@ -14,9 +14,8 @@ import {
   HeaderMenuItem,
   SideNav,
   SideNavItems,
-  HeaderSideNavItems,
+  HeaderSideNavItems
 } from "@carbon/react";
-import { NavLink } from "react-router-dom";
 import * as Icons from "@carbon/icons-react";
 
 import "./BCHeader.scss";

--- a/frontend/src/components/BCHeaderwSide/index.tsx
+++ b/frontend/src/components/BCHeaderwSide/index.tsx
@@ -57,14 +57,14 @@ const listItems = [
         icon: 'Dashboard',
         link: '/testC',
         disabled: false
-      },
+      }
     ]
   }
 ];
 
 const BCHeaderwSide = () => {
   const [myProfile, setMyProfile] = useState<boolean>(false);
-  const [notifications, setNotifications] = useState<boolean>(false);
+  const [_notifications, setNotifications] = useState<boolean>(false);
   const [goToURL, setGoToURL] = useState<string>('');
   const [goTo, setGoTo] = useState<boolean>(false);
 

--- a/frontend/src/components/BCHeaderwSide/index.tsx
+++ b/frontend/src/components/BCHeaderwSide/index.tsx
@@ -64,7 +64,6 @@ const listItems = [
 
 const BCHeaderwSide = () => {
   const [myProfile, setMyProfile] = useState<boolean>(false);
-  const [_notifications, setNotifications] = useState<boolean>(false);
   const [goToURL, setGoToURL] = useState<string>('');
   const [goTo, setGoTo] = useState<boolean>(false);
 
@@ -75,7 +74,6 @@ const BCHeaderwSide = () => {
     } else {
       setMyProfile(true);
     }
-    setNotifications(false);
   }, [myProfile]);
 
   const closeMyProfilePanel = useCallback((): void => {


### PR DESCRIPTION
Fixes several straightforward lint errors:

- Remove unused React import in AvatarImage component
- Fix trailing commas in App.tsx and BCHeaderwSide
- Merge duplicate react-router-dom imports in BCHeader
- Prefix unused notifications variable with underscore to indicate intentional non-use

This addresses some of the lint errors mentioned in issue #225. Additional fixes can be made in follow-up PRs.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-0-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-350-backend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)