### PR TITLE
feat: send admin emails to test taker in TEST environment

### DIFF
--- a/frontend/src/__test__/services/EmailService.test.ts
+++ b/frontend/src/__test__/services/EmailService.test.ts
@@ -92,7 +92,7 @@ describe('EmailService', () => {
       )
     })
 
-    it('should send admin report email in TEST environment', async () => {
+    it('should send admin report email in TEST environment to test taker', async () => {
       env.VITE_ZONE = 'test'
       mockedAxios.post.mockResolvedValueOnce({ data: 'success' })
 
@@ -106,6 +106,14 @@ describe('EmailService', () => {
 
       expect(result).toBe('success')
       expect(mockedAxios.post).toHaveBeenCalledTimes(1)
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://localhost:3000/api/mail',
+        expect.objectContaining({
+          fromEmail: 'test@gov.bc.ca',
+          toEmails: ['john@example.com'],
+          subject: 'Test A admin report : John Doe'
+        })
+      )
     })
 
     it('should NOT send admin report email in PR environment (numeric zone)', async () => {
@@ -179,6 +187,14 @@ describe('EmailService', () => {
 
       expect(result).toBe('success')
       expect(mockedAxios.post).toHaveBeenCalledTimes(1)
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://localhost:3000/api/mail',
+        expect.objectContaining({
+          fromEmail: 'test@gov.bc.ca',
+          toEmails: ['admin@gov.bc.ca'],
+          subject: 'Test A admin report : John Doe'
+        })
+      )
     })
 
     it('should handle case-insensitive environment names for TEST', async () => {
@@ -195,6 +211,14 @@ describe('EmailService', () => {
 
       expect(result).toBe('success')
       expect(mockedAxios.post).toHaveBeenCalledTimes(1)
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://localhost:3000/api/mail',
+        expect.objectContaining({
+          fromEmail: 'test@gov.bc.ca',
+          toEmails: ['john@example.com'],
+          subject: 'Test A admin report : John Doe'
+        })
+      )
     })
 
     it('should return error when email sending fails in PROD', async () => {

--- a/frontend/src/services/EmailService.ts
+++ b/frontend/src/services/EmailService.ts
@@ -100,9 +100,13 @@ export const sendAdminReport = async (userName: string, userEmail: string, perce
   const adminEmail = env.VITE_CHES_ADMIN_EMAIL || 'resultsaccess@gov.bc.ca'
   const backendUrl = env.VITE_BACKEND_URL
 
+  // In TEST environment, send admin report to test taker's email
+  // In PROD environment, send to admin email address
+  const recipientEmail = zone === 'test' ? userEmail : adminEmail
+
   const emailParams: any = {
     fromEmail,
-    toEmails: [adminEmail], // Admin's email address
+    toEmails: [recipientEmail],
     subject: `${testName} admin report : ${userName}`,
     mailBody: emailBody
   }


### PR DESCRIPTION
## Summary

This PR modifies the admin email behavior so that TEST environment sends admin report emails to the test taker's email address instead of the admin mailbox. This prevents spamming `resultsaccess@gov.bc.ca` with test results from the TEST environment.

## Changes

- **EmailService.ts**: Updated `sendAdminReport` to conditionally set recipient based on environment:
  - **TEST**: Sends to test taker's email (`userEmail`)
  - **PROD**: Sends to admin email (`resultsaccess@gov.bc.ca`)
  - **PR environments**: Skips sending (unchanged)

- **EmailService.test.ts**: Updated tests to verify new behavior:
  - TEST environment test verifies email sent to test taker
  - PROD environment test verifies email sent to admin
  - Case-insensitive handling verified for both environments

## Behavior

| Environment | Admin Email Recipient | User Email |
|------------|----------------------|------------|
| PROD | ✓ Admin mailbox | ✓ Sent |
| TEST | ✓ Test taker's email | ✓ Sent |
| PR/Dev | ✗ Skipped | ✓ Sent |

## Testing

All tests passing (10/10):
- ✅ PROD sends to admin email
- ✅ TEST sends to test taker email
- ✅ PR environments skip sending
- ✅ Case-insensitive matching works
- ✅ Error handling verified

## Related

Follow-up to PR #344 which restricted admin emails to TEST and PROD environments only.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-3-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-353-backend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)