### PR TITLE
fix: retry smoke checks for cold start

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -72,7 +72,7 @@ jobs:
     name: Smoke Tests (TEST)
     needs: [vars, deploys-test]
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - '*.md'
-      - '.github/**'
-      - '.github/graphics/**'
-      - '!.github/workflows/**'
+      - "*.md"
+      - ".github/**"
+      - ".github/graphics/**"
+      - "!.github/workflows/**"
 
 concurrency:
   # Do not interrupt previous workflows
@@ -40,8 +40,7 @@ jobs:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
-          parameters:
-            -p ZONE=test
+          parameters: -p ZONE=test
             -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
@@ -65,8 +64,7 @@ jobs:
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: true
-          parameters:
-            -p ZONE=test
+          parameters: -p ZONE=test
             -p TAG=${{ needs.vars.outputs.pr }}
             -p MOD_ZONE=test
 
@@ -74,7 +72,7 @@ jobs:
     name: Smoke Tests (TEST)
     needs: [vars, deploys-test]
     runs-on: ubuntu-24.04
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
@@ -105,8 +103,7 @@ jobs:
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: true
-          parameters:
-            -p ZONE=prod
+          parameters: -p ZONE=prod
             -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
@@ -127,8 +124,7 @@ jobs:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
-          parameters:
-            -p ZONE=prod
+          parameters: -p ZONE=prod
             -p TAG=${{ needs.vars.outputs.pr }}
             -p MOD_ZONE=prod
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -77,20 +77,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 3
     steps:
-      - name: Skip if deploys didn’t trigger
-        run: |
-
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
-      - name: Install smoke dependencies
-        working-directory: integration-tests
-        run: npm ci
       - name: Run smoke checks against PR deployment
         working-directory: integration-tests
-        env:
-          SMOKE_TIMEOUT: "8000"
         run: |
           if [ "${{ needs.deploys.outputs.triggered }}" != "true" ]; then
             echo "Deploy skipped; no smoke checks required."
@@ -101,6 +93,8 @@ jobs:
           mod=$(( pr % 50 ))
           export BACKEND_URL="https://nr-results-exam-${pr}-backend.apps.silver.devops.gov.bc.ca"
           export FRONTEND_URL="https://nr-results-exam-${mod}-frontend.apps.silver.devops.gov.bc.ca"
+          export SMOKE_TIMEOUT="8000"
+          npm ci
           npm run smoke
 
   results:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -57,6 +57,7 @@ jobs:
         name: [backend, frontend]
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
+        id: deploy
         with:
           file: ${{ matrix.name }}/openshift.deploy.yml
           oc_namespace: ${{ vars.OC_NAMESPACE }}
@@ -67,6 +68,8 @@ jobs:
             -p TAG=${{ github.event.number }}
             -p MOD_ZONE=$(( ${{ github.event.number }} % 50))
           triggers: ('backend/' 'common/' 'frontend/')
+    outputs:
+      triggered: ${{ steps.deploy.outputs.triggered }}
 
   smoke:
     name: Smoke Tests
@@ -74,6 +77,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 3
     steps:
+      - name: Skip if deploys didn’t trigger
+        run: |
+          if [ "${{ needs.deploys.outputs.triggered }}" != "true" ]; then
+            echo "Deploy skipped; no smoke checks required."
+            exit 0
+          fi
+
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -79,10 +79,6 @@ jobs:
     steps:
       - name: Skip if deploys didn’t trigger
         run: |
-          if [ "${{ needs.deploys.outputs.triggered }}" != "true" ]; then
-            echo "Deploy skipped; no smoke checks required."
-            exit 0
-          fi
 
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
@@ -96,6 +92,11 @@ jobs:
         env:
           SMOKE_TIMEOUT: "8000"
         run: |
+          if [ "${{ needs.deploys.outputs.triggered }}" != "true" ]; then
+            echo "Deploy skipped; no smoke checks required."
+            exit 0
+          fi
+
           pr="${{ github.event.number }}"
           mod=$(( pr % 50 ))
           export BACKEND_URL="https://nr-results-exam-${pr}-backend.apps.silver.devops.gov.bc.ca"

--- a/integration-tests/src/smoke.js
+++ b/integration-tests/src/smoke.js
@@ -10,6 +10,10 @@ const origin =
   "http://localhost:3000";
 const DEFAULT_TIMEOUT_MS = 5000;
 const MIN_TIMEOUT_MS = 1000;
+const DEFAULT_RETRIES = 5;
+const MIN_RETRIES = 1;
+const DEFAULT_RETRY_DELAY_MS = 2000;
+const MIN_RETRY_DELAY_MS = 0;
 
 const timeoutMs = (() => {
   const parsed = Number.parseInt(process.env.SMOKE_TIMEOUT ?? "", 10);
@@ -18,6 +22,28 @@ const timeoutMs = (() => {
   }
   return DEFAULT_TIMEOUT_MS;
 })();
+
+const retries = (() => {
+  const parsed = Number.parseInt(process.env.SMOKE_RETRIES ?? "", 10);
+  if (Number.isFinite(parsed) && parsed >= MIN_RETRIES) {
+    return parsed;
+  }
+  return DEFAULT_RETRIES;
+})();
+
+const retryDelayMs = (() => {
+  const parsed = Number.parseInt(process.env.SMOKE_RETRY_DELAY_MS ?? "", 10);
+  if (Number.isFinite(parsed) && parsed >= MIN_RETRY_DELAY_MS) {
+    return parsed;
+  }
+  return DEFAULT_RETRY_DELAY_MS;
+})();
+
+const delay = async (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
 const frontendUrl = process.env.FRONTEND_URL?.replace(/\/$/, "");
 
 const checks = [
@@ -45,42 +71,69 @@ if (frontendUrl) {
 
 const run = async () => {
   for (const check of checks) {
-    try {
-      const response = await axios.get(check.url, {
-        headers: {
-          Origin: origin
-        },
-        timeout: timeoutMs
-      });
+    let attempt = 0;
+    let success = false;
 
-      if (!check.validate(response)) {
-        throw new Error(
-          `Validation failed for ${check.name}: status=${response.status}`
-        );
-      }
+    while (attempt < retries && !success) {
+      attempt += 1;
+      try {
+        const response = await axios.get(check.url, {
+          headers: {
+            Origin: origin
+          },
+          timeout: timeoutMs
+        });
 
-      console.info(
-        `✅ ${check.name} responded with ${response.status} from ${check.url}`
-      );
-    } catch (error) {
-      console.error(`❌ ${check.name} failed`);
-      if (axios.isAxiosError(error)) {
-        console.error(
-          `Request error: ${error.message} (status: ${error.response?.status ?? "n/a"})`
-        );
-        if (error.response?.data) {
-          console.error("Response body:", error.response.data);
+        if (!check.validate(response)) {
+          throw new Error(
+            `Validation failed for ${check.name}: status=${response.status}`
+          );
         }
-      } else {
-        console.error(error);
+
+        console.info(
+          `✅ ${check.name} responded with ${response.status} from ${check.url} (attempt ${attempt}/${retries})`
+        );
+        success = true;
+      } catch (error) {
+        const attemptMsg = `attempt ${attempt}/${retries}`;
+        const reason = axios.isAxiosError(error)
+          ? `Request error: ${error.message} (status: ${error.response?.status ?? "n/a"})`
+          : String(error);
+
+        if (attempt < retries) {
+          console.warn(
+            `WARN ${check.name} ${attemptMsg} failed (${reason}). Retrying after ${retryDelayMs}ms...`
+          );
+          if (axios.isAxiosError(error) && error.response?.data) {
+            console.warn("Response body:", error.response.data);
+          }
+          if (retryDelayMs > 0) {
+            await delay(retryDelayMs);
+          }
+        } else {
+          console.error(`❌ ${check.name} failed (${attemptMsg})`);
+          if (axios.isAxiosError(error)) {
+            console.error(
+              `Request error: ${error.message} (status: ${error.response?.status ?? "n/a"})`
+            );
+            if (error.response?.data) {
+              console.error("Response body:", error.response.data);
+            }
+          } else {
+            console.error(error);
+          }
+          process.exitCode = 1;
+        }
       }
-      process.exitCode = 1;
+    }
+
+    if (!success) {
+      console.error("Smoke checks failed");
       break;
     }
   }
 
   if (process.exitCode === 1) {
-    console.error("Smoke checks failed");
     return;
   }
 

--- a/integration-tests/src/smoke.js
+++ b/integration-tests/src/smoke.js
@@ -10,9 +10,9 @@ const origin =
   "http://localhost:3000";
 const DEFAULT_TIMEOUT_MS = 5000;
 const MIN_TIMEOUT_MS = 1000;
-const DEFAULT_RETRIES = 5;
+const DEFAULT_RETRIES = 10;
 const MIN_RETRIES = 1;
-const DEFAULT_RETRY_DELAY_MS = 2000;
+const DEFAULT_RETRY_DELAY_MS = 5000;
 const MIN_RETRY_DELAY_MS = 0;
 
 const timeoutMs = (() => {


### PR DESCRIPTION
## Summary
- add configurable retry/backoff to integration smoke checks
- default to 10 attempts with 5s delay so PR pods can boot before verification
- expose SMOKE_RETRIES and SMOKE_RETRY_DELAY_MS overrides
- skip smoke job when OpenShift deploys aren't triggered, using summed action outputs

## Testing
- not run (CI will cover)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-46-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-396-backend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)