### PR TITLE
chore(ci): add permissions for build attestations

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -14,6 +14,8 @@ jobs:
     name: Builds
     runs-on: ubuntu-24.04
     permissions:
+      attestations: write
+      id-token: write
       packages: write
     strategy:
       matrix:


### PR DESCRIPTION
Add permissions for build attestations to be stored.  Without they're not retained.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-27-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-27-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)