### PR TITLE
feat: expose dependency status in health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ are fully automated:
 - `/health` now includes dependency probes for CHES, the S3/MinIO bucket, and Cognito (FAM).  
   The endpoint caches results for 60 seconds and returns `503` if any dependency reports `status: "error"`.
 - Append `?deep=true` to force a live probe when troubleshooting (synthetic monitors can call the same URL).
-- Responses list each dependency with `status`, the last check timestamp, and error details when something goes down.
+- Responses list each dependency with `status`, latency, and bucket/endpoint metadata. The payload also exposes `lastCheckedAt` and `refreshInProgress` so operators know whether the values are cached.
 
 ### Automerge Expectations
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ are fully automated:
   `packageRules` block locally; otherwise defer to the upstream config to stay
   aligned with NRIDS best practices.
 
+### Runtime Health Checks
+
+- `/health` now includes dependency probes for CHES, the S3/MinIO bucket, and Cognito (FAM).  
+  The endpoint caches results for 60 seconds and returns `503` if any dependency reports `status: "error"`.
+- Append `?deep=true` to force a live probe when troubleshooting (synthetic monitors can call the same URL).
+- Responses list each dependency with `status`, the last check timestamp, and error details when something goes down.
+
 ### Automerge Expectations
 
 **When Automerge Occurs:**

--- a/backend/API.md
+++ b/backend/API.md
@@ -49,6 +49,7 @@ Use `GET /health?deep=true` to force a live dependency check instead of the cach
   "uptime": 12345.67,
   "timestamp": 1234567890123,
   "lastCheckedAt": 1234567889000,
+  "refreshInProgress": false,
   "dependencies": {
     "ches": {
       "status": "ok",
@@ -56,6 +57,7 @@ Use `GET /health?deep=true` to force a live dependency check instead of the cach
     },
     "objectStorage": {
       "status": "ok",
+      "latencyMs": 120,
       "bucket": "nr-results-bucket"
     },
     "federatedAuth": {

--- a/backend/API.md
+++ b/backend/API.md
@@ -39,16 +39,34 @@ The following environment variables must be set for authentication to work:
 
 **GET** `/health`
 
-Returns the health status of the API.
+Returns the API uptime along with dependency status for CHES, S3 object storage, and Cognito (FAM).  
+Use `GET /health?deep=true` to force a live dependency check instead of the cached snapshot.
 
 **Response:**
 ```json
 {
+  "status": "ok",
   "uptime": 12345.67,
-  "message": "OK",
-  "timestamp": 1234567890123
+  "timestamp": 1234567890123,
+  "lastCheckedAt": 1234567889000,
+  "dependencies": {
+    "ches": {
+      "status": "ok",
+      "latencyMs": 150
+    },
+    "objectStorage": {
+      "status": "ok",
+      "bucket": "nr-results-bucket"
+    },
+    "federatedAuth": {
+      "status": "skipped",
+      "message": "VITE_USER_POOLS_ID is not configured"
+    }
+  }
 }
 ```
+
+The HTTP status is `200` when all dependencies are healthy and `503` if any critical dependency reports `status: "error"`.
 
 ### Get Questions (Authenticated)
 

--- a/backend/__tests__/dependencyHealth.test.js
+++ b/backend/__tests__/dependencyHealth.test.js
@@ -1,0 +1,110 @@
+const { describe, test, mock, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const axios = require('axios');
+const Minio = require('minio');
+
+const SERVICE_PATH = '../services/dependencyHealth';
+const ENV_KEYS = [
+  'CHES_CLIENT_ID',
+  'CHES_CLIENT_SECRET',
+  'CHES_TOKEN_URL',
+  'S3_ENDPOINT',
+  'S3_ACCESSKEY',
+  'S3_SECRETKEY',
+  'S3_BUCKETNAME',
+  'VITE_USER_POOLS_ID',
+  'VITE_COGNITO_REGION'
+];
+
+const ORIGINAL_ENV = {};
+
+function loadService() {
+  delete require.cache[require.resolve(SERVICE_PATH)];
+  return require(SERVICE_PATH);
+}
+
+beforeEach(() => {
+  ENV_KEYS.forEach((key) => {
+    ORIGINAL_ENV[key] = process.env[key];
+  });
+
+  process.env.CHES_CLIENT_ID = 'client';
+  process.env.CHES_CLIENT_SECRET = 'secret';
+  process.env.CHES_TOKEN_URL = 'https://example.com/token';
+  process.env.S3_ENDPOINT = 's3.example.com';
+  process.env.S3_ACCESSKEY = 'access';
+  process.env.S3_SECRETKEY = 'secret';
+  process.env.S3_BUCKETNAME = 'bucket';
+  process.env.VITE_USER_POOLS_ID = 'pool';
+  process.env.VITE_COGNITO_REGION = 'ca-central-1';
+});
+
+afterEach(() => {
+  mock.restoreAll();
+  ENV_KEYS.forEach((key) => {
+    const value = ORIGINAL_ENV[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  });
+});
+
+describe('dependencyHealth', () => {
+  test('reports ok when all dependencies succeed', async () => {
+    mock.method(axios, 'post', async () => ({}));
+    mock.method(axios, 'get', async () => ({}));
+    mock.method(Minio, 'Client', function FakeClient() {
+      return { bucketExists: async () => true };
+    });
+
+    const service = loadService();
+    const result = await service.getHealthStatus({ forceRefresh: true });
+
+    assert.strictEqual(result.status, 'ok');
+    assert.strictEqual(result.dependencies.ches.status, 'ok');
+    assert.strictEqual(result.dependencies.objectStorage.status, 'ok');
+    assert.strictEqual(result.dependencies.federatedAuth.status, 'ok');
+  });
+
+  test('marks dependency as error when checks fail', async () => {
+    mock.method(axios, 'post', async () => {
+      throw Object.assign(new Error('boom'), { response: { status: 500, statusText: 'fail' } });
+    });
+    mock.method(axios, 'get', async () => ({}));
+    mock.method(Minio, 'Client', function FakeClient() {
+      return { bucketExists: async () => false };
+    });
+
+    const service = loadService();
+    const result = await service.getHealthStatus({ forceRefresh: true });
+
+    assert.strictEqual(result.status, 'error');
+    assert.strictEqual(result.dependencies.ches.status, 'error');
+    assert.strictEqual(result.dependencies.objectStorage.status, 'error');
+  });
+
+  test('forceRefresh bypasses cached snapshot', async () => {
+    const postMock = mock.method(axios, 'post', async () => ({}));
+    mock.method(axios, 'get', async () => ({}));
+    const bucketExists = mock.fn(async () => true);
+    mock.method(Minio, 'Client', function FakeClient() {
+      return { bucketExists };
+    });
+
+    const service = loadService();
+    await service.getHealthStatus({ forceRefresh: true });
+
+    postMock.mock.mockImplementation(async () => {
+      throw Object.assign(new Error('later'), { response: { status: 500, statusText: 'fail' } });
+    });
+
+    const cached = await service.getHealthStatus();
+    assert.strictEqual(cached.status, 'ok');
+
+    const refreshed = await service.getHealthStatus({ forceRefresh: true });
+    assert.strictEqual(refreshed.status, 'error');
+  });
+});
+

--- a/backend/__tests__/health.test.js
+++ b/backend/__tests__/health.test.js
@@ -1,13 +1,14 @@
-const { test, describe } = require('node:test');
+const { test, describe, mock } = require('node:test');
 const assert = require('node:assert/strict');
 const request = require('supertest');
 const express = require('express');
 
 // Import the health routes
 const healthRoutes = require('../routes/healthRoutes');
+const dependencyHealth = require('../services/dependencyHealth');
 
 describe('Health Routes', () => {
-  test('GET /health should return 200 with uptime and message', async () => {
+  test('GET /health should return dependency snapshot', async () => {
     const app = express();
     app.use('/health', healthRoutes);
 
@@ -15,22 +16,62 @@ describe('Health Routes', () => {
       .get('/health')
       .expect(200);
 
-    assert.strictEqual(response.body.message, 'OK');
+    assert.strictEqual(response.body.status, 'ok');
     assert(typeof response.body.uptime === 'number');
     assert(typeof response.body.timestamp === 'number');
-    assert(response.body.uptime >= 0);
+    assert.deepStrictEqual(
+      Object.keys(response.body.dependencies).sort(),
+      ['ches', 'federatedAuth', 'objectStorage'].sort()
+    );
+    assert.strictEqual(response.body.dependencies.ches.status, 'skipped');
   });
 
-  test('GET /health should return valid JSON', async () => {
+  test('GET /health should return 503 when dependency fails', async () => {
     const app = express();
     app.use('/health', healthRoutes);
 
+    const restore = mock.method(dependencyHealth, 'getHealthStatus', () =>
+      Promise.resolve({
+        status: 'error',
+        checkedAt: Date.now(),
+        dependencies: {
+          ches: { status: 'error', error: 'boom' },
+          federatedAuth: { status: 'ok' },
+          objectStorage: { status: 'ok' }
+        }
+      })
+    );
+
     const response = await request(app)
       .get('/health')
-      .expect('Content-Type', /json/)
+      .expect(503);
+
+    assert.strictEqual(response.body.status, 'error');
+    restore.mock.restore();
+  });
+
+  test('GET /health?deep=true should trigger fresh check', async () => {
+    const app = express();
+    app.use('/health', healthRoutes);
+
+    const restore = mock.method(dependencyHealth, 'getHealthStatus', ({ forceRefresh }) =>
+      Promise.resolve({
+        status: forceRefresh ? 'ok' : 'error',
+        checkedAt: Date.now(),
+        dependencies: {
+          ches: { status: 'skipped' },
+          federatedAuth: { status: 'skipped' },
+          objectStorage: { status: 'skipped' }
+        }
+      })
+    );
+
+    const response = await request(app)
+      .get('/health?deep=true')
       .expect(200);
 
-    assert.deepStrictEqual(Object.keys(response.body).sort(), ['message', 'timestamp', 'uptime'].sort());
+    assert.strictEqual(response.body.status, 'ok');
+    restore.mock.restore();
   });
 });
 

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -136,14 +136,14 @@ objects:
                   memory: "${MEMORY_LIMIT}"
               readinessProbe:
                 httpGet:
-                  path: /health
+                  path: /health?deep=true
                   port: 5000
                   scheme: HTTP
-                initialDelaySeconds: 5
-                periodSeconds: 2
-                timeoutSeconds: 2
+                initialDelaySeconds: 25
+                periodSeconds: 20
+                timeoutSeconds: 5
                 successThreshold: 1
-                failureThreshold: 30
+                failureThreshold: 4
               livenessProbe:
                 successThreshold: 1
                 failureThreshold: 3

--- a/backend/routes/healthRoutes.js
+++ b/backend/routes/healthRoutes.js
@@ -13,10 +13,12 @@ router.get('/', async (req, res) => {
       uptime: process.uptime(),
       timestamp: Date.now(),
       lastCheckedAt: health.checkedAt,
+      refreshInProgress: health.refreshInProgress,
       dependencies: health.dependencies
     };
 
-    const httpStatus = health.status === 'error' ? 503 : 200;
+    const httpStatus =
+      health.status === 'error' || health.status === 'degraded' ? 503 : 200;
     res.status(httpStatus).json(payload);
   } catch (error) {
     console.error('Health check error:', error);

--- a/backend/routes/healthRoutes.js
+++ b/backend/routes/healthRoutes.js
@@ -1,12 +1,12 @@
 const express = require('express');
-const { getHealthStatus } = require('../services/dependencyHealth');
+const dependencyHealth = require('../services/dependencyHealth');
 
 const router = express.Router({});
 
 router.get('/', async (req, res) => {
   try {
     const forceRefresh = req.query.deep === 'true';
-    const health = await getHealthStatus({ forceRefresh });
+    const health = await dependencyHealth.getHealthStatus({ forceRefresh });
 
     const payload = {
       status: health.status,

--- a/backend/routes/healthRoutes.js
+++ b/backend/routes/healthRoutes.js
@@ -1,12 +1,30 @@
 const express = require('express');
+const { getHealthStatus } = require('../services/dependencyHealth');
+
 const router = express.Router({});
 
-router.get('/', async (_req, res, _next) => {
-  res.send({
-    uptime: process.uptime(),
-    message: 'OK',
-    timestamp: Date.now()
-  });
+router.get('/', async (req, res) => {
+  try {
+    const forceRefresh = req.query.deep === 'true';
+    const health = await getHealthStatus({ forceRefresh });
+
+    const payload = {
+      status: health.status,
+      uptime: process.uptime(),
+      timestamp: Date.now(),
+      lastCheckedAt: health.checkedAt,
+      dependencies: health.dependencies
+    };
+
+    const httpStatus = health.status === 'error' ? 503 : 200;
+    res.status(httpStatus).json(payload);
+  } catch (error) {
+    console.error('Health check error:', error);
+    res.status(500).json({
+      status: 'error',
+      message: 'Unable to compute health status'
+    });
+  }
 });
 
 module.exports = router;

--- a/backend/services/dependencyHealth.js
+++ b/backend/services/dependencyHealth.js
@@ -1,0 +1,229 @@
+const axios = require('axios');
+const Minio = require('minio');
+
+const DEFAULT_TIMEOUT_MS = Number(process.env.HEALTH_DEPENDENCY_TIMEOUT_MS ?? 5000);
+const CACHE_TTL_MS = Number(process.env.HEALTH_DEPENDENCY_CACHE_MS ?? 60000);
+
+let lastSnapshot = null;
+let lastUpdated = 0;
+let refreshPromise = null;
+let minioClient;
+
+function formatAxiosError(error) {
+  if (error.response) {
+    return `${error.response.status} ${error.response.statusText}`;
+  }
+  if (error.code) {
+    return `${error.code}`;
+  }
+  return error.message ?? 'Unknown error';
+}
+
+async function checkChes() {
+  const clientId = process.env.CHES_CLIENT_ID;
+  const clientSecret = process.env.CHES_CLIENT_SECRET;
+  const tokenUrl =
+    process.env.CHES_TOKEN_URL ??
+    'https://test.loginproxy.gov.bc.ca/auth/realms/comsvcauth/protocol/openid-connect/token';
+
+  if (!clientId || !clientSecret) {
+    return {
+      status: 'skipped',
+      message: 'CHES credentials are not configured'
+    };
+  }
+
+  const started = Date.now();
+
+  try {
+    await axios.post('' + tokenUrl, 'grant_type=client_credentials', {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      auth: { username: clientId, password: clientSecret },
+      timeout: DEFAULT_TIMEOUT_MS
+    });
+
+    return {
+      status: 'ok',
+      latencyMs: Date.now() - started,
+      endpoint: tokenUrl
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      latencyMs: Date.now() - started,
+      error: formatAxiosError(error)
+    };
+  }
+}
+
+function getMinioClient() {
+  if (minioClient) {
+    return minioClient;
+  }
+
+  const endPoint = process.env.S3_ENDPOINT;
+  const accessKey = process.env.S3_ACCESSKEY;
+  const secretKey = process.env.S3_SECRETKEY;
+
+  if (!endPoint || !accessKey || !secretKey) {
+    return null;
+  }
+
+  const port = process.env.S3_PORT ? Number(process.env.S3_PORT) : undefined;
+  const useSSL = process.env.S3_USE_SSL !== 'false';
+
+  minioClient = new Minio.Client({
+    endPoint,
+    accessKey,
+    secretKey,
+    useSSL,
+    port
+  });
+
+  return minioClient;
+}
+
+async function checkObjectStore() {
+  const bucketName = process.env.S3_BUCKETNAME;
+  if (!bucketName) {
+    return {
+      status: 'skipped',
+      message: 'S3 bucket is not configured'
+    };
+  }
+
+  const client = getMinioClient();
+  if (!client) {
+    return {
+      status: 'skipped',
+      message: 'S3 credentials are not configured'
+    };
+  }
+
+  const started = Date.now();
+  try {
+    const exists = await client.bucketExists(bucketName);
+    if (!exists) {
+      return {
+        status: 'error',
+        latencyMs: Date.now() - started,
+        error: `Bucket ${bucketName} does not exist`
+      };
+    }
+
+    return {
+      status: 'ok',
+      latencyMs: Date.now() - started,
+      bucket: bucketName
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      latencyMs: Date.now() - started,
+      error: error.message ?? 'Unable to reach bucket'
+    };
+  }
+}
+
+async function checkCognito() {
+  const userPoolId = process.env.VITE_USER_POOLS_ID;
+  if (!userPoolId) {
+    return {
+      status: 'skipped',
+      message: 'VITE_USER_POOLS_ID is not configured'
+    };
+  }
+
+  const region = process.env.VITE_COGNITO_REGION || 'ca-central-1';
+  const wellKnownUrl = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}/.well-known/openid-configuration`;
+
+  const started = Date.now();
+
+  try {
+    await axios.get(wellKnownUrl, { timeout: DEFAULT_TIMEOUT_MS });
+    return {
+      status: 'ok',
+      latencyMs: Date.now() - started,
+      endpoint: wellKnownUrl
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      latencyMs: Date.now() - started,
+      error: formatAxiosError(error)
+    };
+  }
+}
+
+function normalize(dependencies) {
+  return {
+    ches: dependencies.ches,
+    objectStorage: dependencies.objectStorage,
+    federatedAuth: dependencies.federatedAuth
+  };
+}
+
+async function runChecks() {
+  const [ches, objectStorage, federatedAuth] = await Promise.all([
+    checkChes(),
+    checkObjectStore(),
+    checkCognito()
+  ]);
+
+  return { ches, objectStorage, federatedAuth };
+}
+
+function computeOverallStatus(dependencies) {
+  const statuses = Object.values(dependencies)
+    .map((dep) => dep.status)
+    .filter((status) => status !== 'skipped');
+
+  if (statuses.includes('error')) {
+    return 'error';
+  }
+
+  if (statuses.includes('degraded')) {
+    return 'degraded';
+  }
+
+  return 'ok';
+}
+
+async function ensureFresh(forceRefresh = false) {
+  const now = Date.now();
+  const isFresh = lastSnapshot && now - lastUpdated < CACHE_TTL_MS;
+
+  if (!forceRefresh && isFresh) {
+    return lastSnapshot;
+  }
+
+  if (!refreshPromise) {
+    refreshPromise = runChecks()
+      .then((result) => {
+        lastSnapshot = normalize(result);
+        lastUpdated = Date.now();
+        return lastSnapshot;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+}
+
+async function getHealthStatus({ forceRefresh = false } = {}) {
+  const dependencies = await ensureFresh(forceRefresh);
+  const status = computeOverallStatus(dependencies);
+
+  return {
+    status,
+    dependencies,
+    checkedAt: lastUpdated
+  };
+}
+
+module.exports = {
+  getHealthStatus
+};
+


### PR DESCRIPTION
## Summary
- extend  to report CHES, object storage, and Cognito dependency states
- add cached dependency probes with optional  to force live checks
- document the new response shape in README and backend/API.md

## Testing
- Tests were not run locally (npm is unavailable in this environment)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-40-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-40-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)