### PR TITLE
chore(ci): update ZAP for new routes

### DIFF
--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -13,11 +13,13 @@ jobs:
     runs-on: ubuntu-24.04
     name: Penetration Tests
     env:
-      DOMAIN: apps.silver.devops.gov.bc.ca
-      PREFIX: ${{ github.event.repository.name }}-test
+      URL: results-exam-test.apps.silver.devops.gov.bc.ca
     strategy:
       matrix:
         name: [backend, frontend]
+        include:
+          - name: backend
+            path: /health
     steps:
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.13.0
@@ -26,4 +28,4 @@ jobs:
           artifact_name: "zap_${{ matrix.name }}"
           cmd_options: "-a"
           issue_title: "ZAP: ${{ matrix.name }}"
-          target: https://${{ env.PREFIX }}-${{ matrix.name }}.${{ env.DOMAIN }}
+          target: https://${{ env.URL }}${{ matrix.path }}

--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -1,4 +1,4 @@
-name: Penetration Tests
+name: ZAP Penetration Tests
 
 on:
   schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   zap_scan:
     runs-on: ubuntu-24.04
-    name: Penetration Tests
+    name: ZAP Tests
     env:
       URL: results-exam-test.apps.silver.devops.gov.bc.ca
     strategy:
@@ -28,4 +28,4 @@ jobs:
           artifact_name: "zap_${{ matrix.name }}"
           cmd_options: "-a"
           issue_title: "ZAP: ${{ matrix.name }}"
-          target: https://${{ env.URL }}${{ matrix.path }}
+          target: "https://${{ env.URL }}${{ matrix.path }}"

--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -12,20 +12,12 @@ jobs:
   zap_scan:
     runs-on: ubuntu-24.04
     name: ZAP Tests
-    env:
-      URL: results-exam-test.apps.silver.devops.gov.bc.ca
-    strategy:
-      matrix:
-        name: [backend, frontend]
-        include:
-          - name: backend
-            path: /health
     steps:
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.13.0
         with:
           allow_issue_writing: true
-          artifact_name: "zap_${{ matrix.name }}"
+          artifact_name: "zap"
           cmd_options: "-a"
-          issue_title: "ZAP: ${{ matrix.name }}"
-          target: "https://${{ env.URL }}${{ matrix.path }}"
+          issue_title: "ZAP Penetration Test"
+          target: "https://results-exam-test.apps.silver.devops.gov.bc.ca"


### PR DESCRIPTION
- **chore(ci): remove backend from ZAP penetration tests**

Backend is only exposed through frontend's Caddy proxy at `/health` endpoint. All other endpoints require JWT authentication and are not directly accessible. Testing the frontend already covers the proxied `/health` endpoint, making separate backend ZAP testing redundant.

**Changes:**
- Removed backend from ZAP test matrix
- Simplified workflow to only test frontend (which includes Caddy proxy)
- Fixed bug where frontend path was undefined in matrix strategy

Part of #419

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-1-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-1.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-1-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)