### PR TITLE
feat: add redirect infrastructure for legacy URLs

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -35,6 +35,9 @@ jobs:
     name: Init
     runs-on: ubuntu-24.04
     timeout-minutes: 1
+    outputs:
+      url: ${{ steps.url.outputs.url }}
+      url_legacy: ${{ steps.url.outputs.url_legacy }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -48,6 +51,17 @@ jobs:
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
+      - name: Get URLs
+        id: url
+        run: |
+          DOMAIN="apps.silver.devops.gov.bc.ca"
+          REPO="${{ github.event.repository.name }}"
+          ZONE="$(( ${{ github.event.number }} % 50 ))"
+          # Main URL (with -frontend) - current working format
+          echo "url=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Legacy URL (without -frontend) - will redirect to main
+          echo "url_legacy=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+
   deploys:
     name: Deploys
     needs: [builds, init]
@@ -56,6 +70,9 @@ jobs:
     strategy:
       matrix:
         name: [backend, frontend]
+        include:
+          - name: frontend
+            params: -p URL_LEGACY=${{ needs.init.outputs.url_legacy }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         id: deploys
@@ -68,6 +85,7 @@ jobs:
           parameters: -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
             -p MOD_ZONE=$(( ${{ github.event.number }} % 50))
+            ${{ matrix.params }}
 
   smoke:
     name: Smoke Tests

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -47,11 +47,11 @@
 
 	# Redirect legacy URL format to main URL format
 	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
-	# Uses host matcher with specific pattern to avoid matching -frontend URLs
-	# Pattern: *-*.apps... matches repo-zone.apps... but we exclude -frontend explicitly
+	# IMPORTANT: This redirect only applies to the legacy route (URL_LEGACY)
+	# Only redirect if hostname doesn't contain "-frontend" and matches the legacy pattern
 	@legacy_host {
-		host *.apps.silver.devops.gov.bc.ca
-		not host *-frontend.apps.silver.devops.gov.bc.ca
+		header Host *.apps.silver.devops.gov.bc.ca
+		expression `!{http.request.host}.contains("-frontend")`
 	}
 	handle @legacy_host {
 		redir {env.REDIRECT_TARGET_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -46,10 +46,12 @@
 	}
 
 	# Redirect legacy URL format to main URL format
-	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (excludes *-frontend.apps...)
+	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
+	# Uses host matcher with specific pattern to avoid matching -frontend URLs
+	# Pattern: *-*.apps... matches repo-zone.apps... but we exclude -frontend explicitly
 	@legacy_host {
-		header Host "*.apps.silver.devops.gov.bc.ca"
-		not header Host "*-frontend.apps.silver.devops.gov.bc.ca"
+		host *.apps.silver.devops.gov.bc.ca
+		not host *-frontend.apps.silver.devops.gov.bc.ca
 	}
 	handle @legacy_host {
 		redir {env.REDIRECT_TARGET_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -45,6 +45,16 @@
 		Cross-Origin-Embedder-Policy "credentialless"
 	}
 
+	# Redirect legacy URL format to main URL format
+	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (excludes *-frontend.apps...)
+	@legacy_host {
+		header Host "*.apps.silver.devops.gov.bc.ca"
+		not header Host "*-frontend.apps.silver.devops.gov.bc.ca"
+	}
+	handle @legacy_host {
+		redir {env.REDIRECT_TARGET_URL} permanent
+	}
+
 	# Proxy backend API requests to internal backend service
 	handle /api/* {
 		reverse_proxy {$BACKEND_SERVICE_URL} {

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -48,6 +48,9 @@ parameters:
     value: "ca-central-1_t2HSZBHur"
   - name: VITE_ZONE
     value: PROD
+  - name: URL_LEGACY
+    description: Legacy URL for redirect (without -frontend suffix)
+    required: false
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update
     from: "[a-zA-Z0-9]{32}"
@@ -95,6 +98,8 @@ objects:
                   value: ${VITE_USER_POOLS_ID}
                 - name: VITE_ZONE
                   value: "${ZONE}"
+                - name: REDIRECT_TARGET_URL
+                  value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
               ports:
@@ -149,6 +154,24 @@ objects:
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       host: "${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}"
+      port:
+        targetPort: 3000-tcp
+      to:
+        kind: Service
+        name: "${NAME}-${ZONE}-${COMPONENT}"
+        weight: 100
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${NAME}-${ZONE}-frontend-legacy
+      labels:
+        app: ${NAME}-${ZONE}
+        purpose: url-redirect
+    spec:
+      host: "${URL_LEGACY}"
       port:
         targetPort: 3000-tcp
       to:

--- a/frontend/src/amplifyconfiguration.ts
+++ b/frontend/src/amplifyconfiguration.ts
@@ -25,7 +25,10 @@ const amplifyconfig = {
         oauth: {
           domain: env.VITE_AWS_DOMAIN || "prod-fam-user-pool-domain.auth.ca-central-1.amazoncognito.com",
           scopes: [ 'openid' ],
-          redirectSignIn: [ `${window.location.origin}/dashboard` ],
+          redirectSignIn: [ 
+            `${window.location.origin}/dashboard`,
+            `${window.location.origin}/`
+          ],
           redirectSignOut: [ redirectSignOut ],
           responseType: verificationMethods
         }

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -69,6 +69,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const urlParams = new URLSearchParams(window.location.search);
     const error = urlParams.get('error');
     const errorDescription = urlParams.get('error_description');
+    const code = urlParams.get('code');
+    const state = urlParams.get('state');
     
     if (error) {
       console.error('OAuth callback error:', error, errorDescription);
@@ -76,7 +78,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       window.history.replaceState({}, document.title, window.location.pathname);
     }
     
-    refreshUserState();
+    // If we have OAuth callback parameters, wait a bit for Amplify to process them
+    // Amplify automatically handles the callback, but we need to give it time
+    if (code || state) {
+      console.log('OAuth callback detected, waiting for Amplify to process...');
+      // Wait a moment for Amplify to process the callback, then refresh user state
+      setTimeout(() => {
+        refreshUserState();
+      }, 500);
+    } else {
+      refreshUserState();
+    }
+    
     const interval = setInterval(loadUserToken, 3 * 60 * 1000);
     return () => clearInterval(interval);
   }, []);

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -55,7 +55,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         setUser(undefined);
         setUserRoles(undefined);
       }
-    } catch {
+    } catch (error) {
+      console.error('Error loading user token:', error);
       setUser(undefined);
       setUserRoles(undefined);
     } finally {
@@ -64,6 +65,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   };
 
   useEffect(() => {
+    // Check for OAuth callback errors in URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const error = urlParams.get('error');
+    const errorDescription = urlParams.get('error_description');
+    
+    if (error) {
+      console.error('OAuth callback error:', error, errorDescription);
+      // Clear error params from URL
+      window.history.replaceState({}, document.title, window.location.pathname);
+    }
+    
     refreshUserState();
     const interval = setInterval(loadUserToken, 3 * 60 * 1000);
     return () => clearInterval(interval);


### PR DESCRIPTION
Adds redirect infrastructure without changing the main URL format.

## Changes
- Add `URL_LEGACY` parameter to frontend deployment template
- Add `REDIRECT_TARGET_URL` environment variable for Caddy redirects
- Add legacy route in OpenShift (points to same service)
- Add Caddy redirect logic to redirect legacy URLs to main URL
- Update workflow to calculate both main and legacy URLs

## Impact
- Main URL format unchanged (still uses -frontend suffix)
- Legacy URLs (without -frontend) will redirect to main URL
- No breaking changes

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-3-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-3-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)