### PR TITLE
feat: switch main URL format to short URL (without -frontend)

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -57,10 +57,10 @@ jobs:
           DOMAIN="apps.silver.devops.gov.bc.ca"
           REPO="${{ github.event.repository.name }}"
           ZONE="$(( ${{ github.event.number }} % 50 ))"
-          # Main URL (with -frontend) - current working format
-          echo "url=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
-          # Legacy URL (without -frontend) - will redirect to main
-          echo "url_legacy=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Main URL (without -frontend) - new primary format
+          echo "url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Legacy URL (with -frontend) - will redirect to main
+          echo "url_legacy=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -21,8 +21,8 @@ jobs:
           DOMAIN="apps.silver.devops.gov.bc.ca"
           REPO="${{ github.event.repository.name }}"
           ZONE="$(( ${{ github.event.number }} % 50 ))"
-          # Main URL (with -frontend) - consistent with pr-open.yml
-          echo "url=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Main URL (without -frontend) - new primary format
+          echo "url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
 
   validate:
     name: Validate PR

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -46,10 +46,9 @@
 	}
 
 	# Redirect legacy URL format to main URL format
-	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (excludes *-frontend.apps...)
+	# Matches format: *-<number>-frontend.apps.silver.devops.gov.bc.ca
 	@legacy_host {
-		header Host "*.apps.silver.devops.gov.bc.ca"
-		not header Host "*-frontend.apps.silver.devops.gov.bc.ca"
+		header Host "*-frontend.apps.silver.devops.gov.bc.ca"
 	}
 	handle @legacy_host {
 		redir {env.REDIRECT_TARGET_URL} permanent

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -99,7 +99,7 @@ objects:
                 - name: VITE_ZONE
                   value: "${ZONE}"
                 - name: REDIRECT_TARGET_URL
-                  value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
+                  value: "https://${NAME}-${MOD_ZONE}.${DOMAIN}/"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
               ports:
@@ -153,7 +153,7 @@ objects:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
-      host: "${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}"
+      host: "${NAME}-${MOD_ZONE}.${DOMAIN}"
       port:
         targetPort: 3000-tcp
       to:


### PR DESCRIPTION
Switches main URL format from long format (with -frontend) to short format (without -frontend).

## Changes
- Change main URL from `*-frontend.apps...` to `*.apps...` format
- Update Caddy redirect to redirect legacy -frontend URLs to new main URL
- Update OpenShift route to use new main URL format
- Update all workflows to use new URL format

## Impact
- **Breaking change**: Main URL format changes
- Legacy URLs with -frontend suffix will redirect to new main URL
- Cognito whitelist may need updating for new URL format
- All workflows updated to use new format

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-5.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-5.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)