### PR TITLE
feat: add URL calculation for main and legacy URLs

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -35,6 +35,9 @@ jobs:
     name: Init
     runs-on: ubuntu-24.04
     timeout-minutes: 1
+    outputs:
+      url: ${{ steps.url.outputs.url }}
+      url_legacy: ${{ steps.url.outputs.url_legacy }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -47,6 +50,17 @@ jobs:
             -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
+
+      - name: Calculate URLs
+        id: url
+        run: |
+          DOMAIN="apps.silver.devops.gov.bc.ca"
+          REPO="${{ github.event.repository.name }}"
+          ZONE="$(( ${{ github.event.number }} % 50 ))"
+          # Main URL (with -frontend) - current working format, unchanged
+          echo "url=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Legacy URL (without -frontend) - for future redirect support
+          echo "url_legacy=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys


### PR DESCRIPTION
Calculate both main URL (with -frontend) and legacy URL (without -frontend) in the init job and expose as job outputs.

## Changes
- Add URL calculation step to `init` job
- Calculate `url` (main URL with -frontend) - unchanged format
- Calculate `url_legacy` (legacy URL without -frontend) - for future redirect
- Expose both as job outputs: `needs.init.outputs.url` and `needs.init.outputs.url_legacy`

## Impact
- **No deployment changes** - this PR only calculates values
- Main URL format unchanged
- Prepares for future redirect infrastructure
- No breaking changes

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-7-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-7-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)