### PR TITLE
feat: add URL_LEGACY parameter to deployment template

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -70,6 +70,9 @@ jobs:
     strategy:
       matrix:
         name: [backend, frontend]
+        include:
+          - name: frontend
+            params: -p URL_LEGACY=${{ needs.init.outputs.url_legacy }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         id: deploys
@@ -82,6 +85,7 @@ jobs:
           parameters: -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
             -p MOD_ZONE=$(( ${{ github.event.number }} % 50))
+            ${{ matrix.params }}
 
   smoke:
     name: Smoke Tests

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -48,6 +48,9 @@ parameters:
     value: "ca-central-1_t2HSZBHur"
   - name: VITE_ZONE
     value: PROD
+  - name: URL_LEGACY
+    description: Legacy URL for redirect (without -frontend suffix)
+    required: false
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update
     from: "[a-zA-Z0-9]{32}"


### PR DESCRIPTION
Add URL_LEGACY parameter to frontend deployment template and pass it from the workflow.

## Changes
- Add `URL_LEGACY` parameter (optional) to `frontend/openshift.deploy.yml`
- Pass `URL_LEGACY` from workflow to frontend deployment
- Update workflow to pass `URL_LEGACY` parameter for frontend deployments

## Impact
- **No routes created yet** - this PR only adds the parameter
- Parameter is optional, so existing deployments continue to work
- Prepares for legacy route creation in future PR
- No breaking changes

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-8-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-8-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)