### PR TITLE
feat: add REDIRECT_TARGET_URL environment variable

### DIFF
--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -100,6 +100,8 @@ objects:
                   value: "${ZONE}"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
+                - name: REDIRECT_TARGET_URL
+                  value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
               ports:
                 - containerPort: 3000
                   protocol: TCP


### PR DESCRIPTION
Add REDIRECT_TARGET_URL environment variable to frontend container for Caddy redirect logic.

## Changes
- Add `REDIRECT_TARGET_URL` environment variable to frontend container
- Set to main URL format: `https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/`
- This will be used by Caddy in a future PR to redirect legacy URLs

## Impact
- **No Caddy changes yet** - this PR only adds the environment variable
- Variable is available for future redirect logic
- No breaking changes

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-9-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-9-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)