### PR TITLE
feat: add legacy route in OpenShift

### DIFF
--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -50,7 +50,7 @@ parameters:
     value: PROD
   - name: URL_LEGACY
     description: Legacy URL for redirect (without -frontend suffix)
-    required: false
+    required: true
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update
     from: "[a-zA-Z0-9]{32}"
@@ -154,6 +154,24 @@ objects:
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       host: "${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}"
+      port:
+        targetPort: 3000-tcp
+      to:
+        kind: Service
+        name: "${NAME}-${ZONE}-${COMPONENT}"
+        weight: 100
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${NAME}-${ZONE}-${COMPONENT}-legacy
+      labels:
+        app: ${NAME}-${ZONE}
+        purpose: url-redirect
+    spec:
+      host: "${URL_LEGACY}"
       port:
         targetPort: 3000-tcp
       to:


### PR DESCRIPTION
Add a second OpenShift Route for the legacy URL format (without -frontend).

## Changes
- Add legacy route: `${NAME}-${ZONE}-${COMPONENT}-legacy`
- Route uses `URL_LEGACY` parameter for hostname
- Points to same service as main route
- Make `URL_LEGACY` parameter required (needed for legacy route)

## Impact
- **No Caddy redirect logic yet** - this PR only creates the route
- Legacy URL will be accessible but won't redirect yet
- Route is created alongside main route
- No breaking changes (route only created if URL_LEGACY is provided)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-10-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-10-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)