### PR TITLE
feat: add Caddy redirect logic for legacy URLs

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -17,6 +17,17 @@
 		level {$LOG_LEVEL}
 	}
 
+	# Redirect legacy URL format to main URL format
+	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
+	# Only redirect if hostname doesn't contain "-frontend" and matches the legacy pattern
+	@legacy_host {
+		header Host *.apps.silver.devops.gov.bc.ca
+		expression `!{http.request.host}.contains("-frontend")`
+	}
+	handle @legacy_host {
+		redir {env.REDIRECT_TARGET_URL} permanent
+	}
+
 	header {
 		# Security headers
 		X-Frame-Options "SAMEORIGIN"


### PR DESCRIPTION
Add redirect logic to Caddy to redirect legacy URLs (without -frontend) to the main URL (with -frontend).

## Changes
- Add `@legacy_host` matcher using `header Host` and `expression`
- Expression: `!{http.request.host}.contains("-frontend")` to explicitly exclude main URLs
- Redirect to `REDIRECT_TARGET_URL` environment variable
- Permanent redirect (301) for SEO and caching
- Redirect happens early, before other handlers

## Impact
- Legacy URLs (without -frontend) will redirect to main URL (with -frontend)
- Main URLs (with -frontend) are not affected
- Redirect is permanent (301) for proper SEO
- No breaking changes (only redirects legacy URLs)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-11-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-11-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)