### PR TITLE
feat: add redirect from URL support

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -57,7 +57,7 @@ jobs:
         name: [backend, frontend]
         include:
           - name: frontend
-            params: -p REDIRECT_FROM_URL="results-exam-test.apps.silver.devops.gov.bc.ca"
+            params: -p REDIRECT_FROM_URL="${{ vars.REDIRECT_FROM_URL }}"
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -74,6 +74,7 @@ jobs:
   smoke-test:
     name: Smoke Tests (TEST)
     needs: [vars, deploys-test]
+    environment: test
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -84,7 +85,7 @@ jobs:
       - name: Verify deployed services
         working-directory: integration-tests
         env:
-          FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
+          FRONTEND_URL: https://${{ vars.REDIRECT_FROM_URL }}
         run: |
           npm ci
           npm run smoke
@@ -119,7 +120,7 @@ jobs:
         name: [backend, frontend]
         include:
           - name: frontend
-            params: -p REDIRECT_FROM_URL="results-exam.apps.silver.devops.gov.bc.ca"
+            params: -p REDIRECT_FROM_URL="${{ vars.REDIRECT_FROM_URL }}"
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -135,6 +136,7 @@ jobs:
   smoke-prod:
     name: Smoke Tests (PROD)
     needs: [vars, deploys-prod]
+    environment: prod
     runs-on: ubuntu-24.04
     timeout-minutes: 3
     steps:
@@ -145,7 +147,7 @@ jobs:
       - name: Verify PROD deployment
         working-directory: integration-tests
         env:
-          FRONTEND_URL: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
+          FRONTEND_URL: https://${{ vars.REDIRECT_FROM_URL }}
         run: |
           npm ci
           npm run smoke

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -6,7 +6,6 @@ on:
     paths-ignore:
       - "*.md"
       - ".github/**"
-      - ".github/graphics/**"
       - "!.github/workflows/**"
 
 concurrency:
@@ -33,8 +32,6 @@ jobs:
     environment: test
     runs-on: ubuntu-24.04
     timeout-minutes: 1
-    outputs:
-      redirect_from_url: ${{ steps.url.outputs.redirect_from_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -46,15 +43,6 @@ jobs:
             -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
-
-      - name: Calculate URLs
-        id: url
-        run: |
-          DOMAIN="apps.silver.devops.gov.bc.ca"
-          REPO="${{ github.event.repository.name }}"
-          ZONE="test"
-          # Redirect from URL (without -frontend) - will redirect to main
-          echo "redirect_from_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys-test:
     name: Deploys (TEST)
@@ -69,7 +57,7 @@ jobs:
         name: [backend, frontend]
         include:
           - name: frontend
-            params: -p REDIRECT_FROM_URL=${{ needs.init-test.outputs.redirect_from_url }}
+            params: -p REDIRECT_FROM_URL="results-exam-test.apps.silver.devops.gov.bc.ca"
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -107,8 +95,6 @@ jobs:
     environment: prod
     runs-on: ubuntu-24.04
     timeout-minutes: 1
-    outputs:
-      redirect_from_url: ${{ steps.url.outputs.redirect_from_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -122,15 +108,6 @@ jobs:
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
-      - name: Calculate URLs
-        id: url
-        run: |
-          DOMAIN="apps.silver.devops.gov.bc.ca"
-          REPO="${{ github.event.repository.name }}"
-          ZONE="prod"
-          # Redirect from URL (without -frontend) - will redirect to main
-          echo "redirect_from_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
-
   deploys-prod:
     name: Deploys (PROD)
     needs: [vars, init-prod]
@@ -142,7 +119,7 @@ jobs:
         name: [backend, frontend]
         include:
           - name: frontend
-            params: -p REDIRECT_FROM_URL=${{ needs.init-prod.outputs.redirect_from_url }}
+            params: -p REDIRECT_FROM_URL="results-exam.apps.silver.devops.gov.bc.ca"
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -33,6 +33,8 @@ jobs:
     environment: test
     runs-on: ubuntu-24.04
     timeout-minutes: 1
+    outputs:
+      redirect_from_url: ${{ steps.url.outputs.redirect_from_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -45,6 +47,15 @@ jobs:
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
+      - name: Calculate URLs
+        id: url
+        run: |
+          DOMAIN="apps.silver.devops.gov.bc.ca"
+          REPO="${{ github.event.repository.name }}"
+          ZONE="test"
+          # Redirect from URL (without -frontend) - will redirect to main
+          echo "redirect_from_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+
   deploys-test:
     name: Deploys (TEST)
     needs: [vars, init-test]
@@ -56,6 +67,9 @@ jobs:
     strategy:
       matrix:
         name: [backend, frontend]
+        include:
+          - name: frontend
+            params: -p REDIRECT_FROM_URL=${{ needs.init-test.outputs.redirect_from_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -67,6 +81,7 @@ jobs:
           parameters: -p ZONE=test
             -p TAG=${{ needs.vars.outputs.pr }}
             -p MOD_ZONE=test
+            ${{ matrix.params || '' }}
 
   smoke-test:
     name: Smoke Tests (TEST)
@@ -92,6 +107,8 @@ jobs:
     environment: prod
     runs-on: ubuntu-24.04
     timeout-minutes: 1
+    outputs:
+      redirect_from_url: ${{ steps.url.outputs.redirect_from_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -105,6 +122,15 @@ jobs:
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
+      - name: Calculate URLs
+        id: url
+        run: |
+          DOMAIN="apps.silver.devops.gov.bc.ca"
+          REPO="${{ github.event.repository.name }}"
+          ZONE="prod"
+          # Redirect from URL (without -frontend) - will redirect to main
+          echo "redirect_from_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+
   deploys-prod:
     name: Deploys (PROD)
     needs: [vars, init-prod]
@@ -114,6 +140,9 @@ jobs:
     strategy:
       matrix:
         name: [backend, frontend]
+        include:
+          - name: frontend
+            params: -p REDIRECT_FROM_URL=${{ needs.init-prod.outputs.redirect_from_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -124,6 +153,7 @@ jobs:
           parameters: -p ZONE=prod
             -p TAG=${{ needs.vars.outputs.pr }}
             -p MOD_ZONE=prod
+            ${{ matrix.params || '' }}
 
   smoke-prod:
     name: Smoke Tests (PROD)

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -65,7 +65,6 @@ jobs:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
-          overwrite: true
           parameters: -p ZONE=test
             -p TAG=${{ needs.vars.outputs.pr }}
             -p MOD_ZONE=test
@@ -85,7 +84,7 @@ jobs:
       - name: Verify deployed services
         working-directory: integration-tests
         env:
-          FRONTEND_URL: https://${{ vars.REDIRECT_FROM_URL }}
+          FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke
@@ -103,7 +102,6 @@ jobs:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
-          overwrite: true
           parameters: -p ZONE=prod
             -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
@@ -147,7 +145,7 @@ jobs:
       - name: Verify PROD deployment
         working-directory: integration-tests
         env:
-          FRONTEND_URL: https://${{ vars.REDIRECT_FROM_URL }}
+          FRONTEND_URL: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -85,7 +85,7 @@ jobs:
           parameters: -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
             -p MOD_ZONE=$(( ${{ github.event.number }} % 50))
-            ${{ matrix.params }}
+            ${{ matrix.params || '' }}
 
   smoke:
     name: Smoke Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -35,6 +35,9 @@ jobs:
     name: Init
     runs-on: ubuntu-24.04
     timeout-minutes: 1
+    outputs:
+      url: ${{ steps.url.outputs.url }}
+      url_legacy: ${{ steps.url.outputs.url_legacy }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -48,6 +51,17 @@ jobs:
             -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
+      - name: Calculate URLs
+        id: url
+        run: |
+          DOMAIN="apps.silver.devops.gov.bc.ca"
+          REPO="${{ github.event.repository.name }}"
+          ZONE="$(( ${{ github.event.number }} % 50 ))"
+          # Main URL (with -frontend) - current working format
+          echo "url=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Legacy URL (without -frontend) - will redirect to main
+          echo "url_legacy=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+
   deploys:
     name: Deploys
     needs: [builds, init]
@@ -56,6 +70,9 @@ jobs:
     strategy:
       matrix:
         name: [backend, frontend]
+        include:
+          - name: frontend
+            params: -p URL_LEGACY=${{ needs.init.outputs.url_legacy }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         id: deploys
@@ -68,6 +85,7 @@ jobs:
           parameters: -p ZONE=${{ github.event.number }}
             -p TAG=${{ github.event.number }}
             -p MOD_ZONE=$(( ${{ github.event.number }} % 50))
+            ${{ matrix.params }}
 
   smoke:
     name: Smoke Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 1
     outputs:
       url: ${{ steps.url.outputs.url }}
-      url_legacy: ${{ steps.url.outputs.url_legacy }}
+      redirect_from_url: ${{ steps.url.outputs.redirect_from_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         with:
@@ -59,8 +59,8 @@ jobs:
           ZONE="$(( ${{ github.event.number }} % 50 ))"
           # Main URL (with -frontend) - current working format
           echo "url=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
-          # Legacy URL (without -frontend) - will redirect to main
-          echo "url_legacy=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Redirect from URL (without -frontend) - will redirect to main
+          echo "redirect_from_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys
@@ -72,7 +72,7 @@ jobs:
         name: [backend, frontend]
         include:
           - name: frontend
-            params: -p URL_LEGACY=${{ needs.init.outputs.url_legacy }}
+            params: -p REDIRECT_FROM_URL=${{ needs.init.outputs.redirect_from_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.0
         id: deploys

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -28,6 +28,7 @@ jobs:
     with:
       markdown_links: |
         - [Frontend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}-frontend.apps.silver.devops.gov.bc.ca)
+        - [Frontend (Legacy)](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}.apps.silver.devops.gov.bc.ca)
         - [Backend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}-frontend.apps.silver.devops.gov.bc.ca/health)
 
   results:

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       markdown_links: |
         - [Frontend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}-frontend.apps.silver.devops.gov.bc.ca)
-        - [Frontend (Legacy)](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}.apps.silver.devops.gov.bc.ca)
+        - [Redirect](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}.apps.silver.devops.gov.bc.ca)
         - [Backend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}-frontend.apps.silver.devops.gov.bc.ca/health)
 
   results:

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The application supports two URL formats for backward compatibility during trans
 - **Redirect From URL** (without `-frontend` suffix): `*-<zone>.apps.silver.devops.gov.bc.ca`
   - This format is maintained for backward compatibility
   - Redirect from URLs automatically redirect (301) to the main URL format
-  - The redirect is handled by Caddy using an expression matcher to ensure only redirect from URLs are redirected
+  - The redirect is handled by Caddy using a header matcher to ensure only redirect from URLs are redirected
 
 **Note:** This redirect infrastructure is temporary and will be removed after the transition period is complete. The main URL format (with `-frontend`) should be used for all new integrations and bookmarks.
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ The application supports two URL formats for backward compatibility during trans
 
 - **Redirect From URL** (without `-frontend` suffix): `*-<zone>.apps.silver.devops.gov.bc.ca`
   - This format is maintained for backward compatibility
-  - Redirect from URLs automatically redirect (301) to the main URL format
+  - Redirect from URLs automatically redirect (301 or 308) to the main URL format
+  - Caddy returns a 301 (Moved Permanently) for GET/HEAD requests and a 308 (Permanent Redirect) for other HTTP methods, following standard behavior for permanent redirects
   - The redirect is handled by Caddy using a header matcher to ensure only redirect from URLs are redirected
 
 **Note:** This redirect infrastructure is temporary and will be removed after the transition period is complete. The main URL format (with `-frontend`) should be used for all new integrations and bookmarks.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ The application follows a defense-in-depth approach with restricted network acce
   - Frontend Caddy proxy forwards requests to backend Service using internal cluster DNS
   - Network policies ensure pod-to-pod communication is allowed within the namespace
 
+### URL Formats and Redirects
+
+The application supports two URL formats for backward compatibility during transition:
+
+- **Main URL** (with `-frontend` suffix): `*-<zone>-frontend.apps.silver.devops.gov.bc.ca`
+  - This is the current primary URL format
+  - All new deployments use this format
+  - This URL serves the application normally
+
+- **Legacy URL** (without `-frontend` suffix): `*-<zone>.apps.silver.devops.gov.bc.ca`
+  - This format is maintained for backward compatibility
+  - Legacy URLs automatically redirect (301) to the main URL format
+  - The redirect is handled by Caddy using an expression matcher to ensure only legacy URLs are redirected
+
+**Note:** This redirect infrastructure is temporary and will be removed after the transition period is complete. The main URL format (with `-frontend`) should be used for all new integrations and bookmarks.
+
 ### Security Benefits
 
 - **Reduced Attack Surface**: Backend is not directly reachable from the internet

--- a/README.md
+++ b/README.md
@@ -223,10 +223,10 @@ The application supports two URL formats for backward compatibility during trans
   - All new deployments use this format
   - This URL serves the application normally
 
-- **Legacy URL** (without `-frontend` suffix): `*-<zone>.apps.silver.devops.gov.bc.ca`
+- **Redirect From URL** (without `-frontend` suffix): `*-<zone>.apps.silver.devops.gov.bc.ca`
   - This format is maintained for backward compatibility
-  - Legacy URLs automatically redirect (301) to the main URL format
-  - The redirect is handled by Caddy using an expression matcher to ensure only legacy URLs are redirected
+  - Redirect from URLs automatically redirect (301) to the main URL format
+  - The redirect is handled by Caddy using an expression matcher to ensure only redirect from URLs are redirected
 
 **Note:** This redirect infrastructure is temporary and will be removed after the transition period is complete. The main URL format (with `-frontend`) should be used for all new integrations and bookmarks.
 

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -17,16 +17,16 @@
 		level {$LOG_LEVEL}
 	}
 
-	# Redirect legacy URL format to main URL format
+	# Redirect from URL format to main URL format
 	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
-	# Only redirect if hostname doesn't contain "-frontend" and matches the legacy pattern
+	# Only redirect if hostname doesn't contain "-frontend" and matches the redirect from pattern
 	# Redirects are logged in Caddy access logs with status 301
-	@legacy_host {
+	@redirect_from_host {
 		header Host *.apps.silver.devops.gov.bc.ca
 		expression `!http.request.host.contains("-frontend")`
 	}
-	handle @legacy_host {
-		redir {env.REDIRECT_TARGET_URL} permanent
+	handle @redirect_from_host {
+		redir {env.REDIRECT_TO_URL} permanent
 	}
 
 	header {

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -23,7 +23,7 @@
 	# Redirects are logged in Caddy access logs with status 301
 	@legacy_host {
 		header Host *.apps.silver.devops.gov.bc.ca
-		expression `!{http.request.host.contains("-frontend")}`
+		expression `!http.request.host.contains("-frontend")`
 	}
 	handle @legacy_host {
 		redir {env.REDIRECT_TARGET_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -17,6 +17,21 @@
 		level {$LOG_LEVEL}
 	}
 
+	# Redirect from URL format to main URL format
+	# Only redirect URLs that match *.apps.silver.devops.gov.bc.ca but don't contain "-frontend"
+	# This ensures main URLs (with -frontend) are never redirected
+	@redirect_from_host {
+		header Host {
+			*.apps.silver.devops.gov.bc.ca
+		}
+		not header Host {
+			*-frontend.apps.silver.devops.gov.bc.ca
+		}
+	}
+	handle @redirect_from_host {
+		redir {env.REDIRECT_TO_URL} permanent
+	}
+
 	header {
 		# Security headers
 		X-Frame-Options "SAMEORIGIN"

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -24,7 +24,7 @@
 		header Host {env.REDIRECT_FROM_HOST}
 	}
 	handle @redirect_from_host {
-		redir {env.REDIRECT_TO_URL} permanent
+		redir {env.URL} permanent
 	}
 
 	header {

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -23,7 +23,7 @@
 	# Redirects are logged in Caddy access logs with status 301
 	@legacy_host {
 		header Host *.apps.silver.devops.gov.bc.ca
-		expression `!{http.request.host}.contains("-frontend")`
+		expression `!{http.request.host.contains("-frontend")}`
 	}
 	handle @legacy_host {
 		redir {env.REDIRECT_TARGET_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -23,7 +23,7 @@
 	# Redirects are logged in Caddy access logs with status 301
 	@redirect_from_host {
 		header Host *.apps.silver.devops.gov.bc.ca
-		expression `!http.request.host.contains("-frontend")`
+		not host *-frontend.apps.silver.devops.gov.bc.ca
 	}
 	handle @redirect_from_host {
 		redir {env.REDIRECT_TO_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -17,6 +17,17 @@
 		level {$LOG_LEVEL}
 	}
 
+	# Redirect legacy URL format to main URL format
+	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
+	# Only redirect if hostname doesn't contain "-frontend" and matches the legacy pattern
+	@legacy_host {
+		header Host *.apps.silver.devops.gov.bc.ca
+		expression `!{http.request.host}.contains("-frontend")`
+	}
+	handle @legacy_host {
+		redir {env.REDIRECT_TARGET_URL} permanent
+	}
+
 	header {
 		# Security headers
 		X-Frame-Options "SAMEORIGIN"

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -21,13 +21,11 @@
 	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
 	# Only redirect if hostname doesn't contain "-frontend" and matches the redirect from pattern
 	# Redirects are logged in Caddy access logs with status 301
-	# Match only URLs that match *.apps.silver.devops.gov.bc.ca but explicitly exclude *-frontend.apps.silver.devops.gov.bc.ca
-	# Using a more restrictive pattern to avoid catching main URLs
+	# Use header matcher to check Host header and exclude URLs containing "-frontend"
+	# This is more reliable than glob patterns with 'not' directive
 	@redirect_from_host {
-		host *.apps.silver.devops.gov.bc.ca
-		not {
-			host *-frontend.apps.silver.devops.gov.bc.ca
-		}
+		header Host *.apps.silver.devops.gov.bc.ca
+		not header Host *-frontend*.apps.silver.devops.gov.bc.ca
 	}
 	handle @redirect_from_host {
 		redir {env.REDIRECT_TO_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -21,11 +21,10 @@
 	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
 	# Only redirect if hostname doesn't contain "-frontend" and matches the redirect from pattern
 	# Redirects are logged in Caddy access logs with status 301
+	# Use a more specific pattern to avoid matching main URLs
 	@redirect_from_host {
 		host *.apps.silver.devops.gov.bc.ca
-		not {
-			host *-frontend.apps.silver.devops.gov.bc.ca
-		}
+		not host *-frontend*.apps.silver.devops.gov.bc.ca
 	}
 	handle @redirect_from_host {
 		redir {env.REDIRECT_TO_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -21,12 +21,8 @@
 	# Only redirect URLs that match *.apps.silver.devops.gov.bc.ca but don't contain "-frontend"
 	# This ensures main URLs (with -frontend) are never redirected
 	@redirect_from_host {
-		header Host {
-			*.apps.silver.devops.gov.bc.ca
-		}
-		not header Host {
-			*-frontend.apps.silver.devops.gov.bc.ca
-		}
+		header Host *.apps.silver.devops.gov.bc.ca
+		not header Host *-frontend.apps.silver.devops.gov.bc.ca
 	}
 	handle @redirect_from_host {
 		redir {env.REDIRECT_TO_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -22,8 +22,10 @@
 	# Only redirect if hostname doesn't contain "-frontend" and matches the redirect from pattern
 	# Redirects are logged in Caddy access logs with status 301
 	@redirect_from_host {
-		header Host *.apps.silver.devops.gov.bc.ca
-		not host *-frontend.apps.silver.devops.gov.bc.ca
+		host *.apps.silver.devops.gov.bc.ca
+		not {
+			host *-frontend.apps.silver.devops.gov.bc.ca
+		}
 	}
 	handle @redirect_from_host {
 		redir {env.REDIRECT_TO_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -18,11 +18,10 @@
 	}
 
 	# Redirect from URL format to main URL format
-	# Only redirect URLs that match *.apps.silver.devops.gov.bc.ca but don't contain "-frontend"
-	# This ensures main URLs (with -frontend) are never redirected
+	# Match only the specific redirect-from hostname from environment variable
+	# This ensures only the intended redirect-from URL is redirected, not main URLs
 	@redirect_from_host {
-		header Host *.apps.silver.devops.gov.bc.ca
-		not header Host *-frontend.apps.silver.devops.gov.bc.ca
+		header Host {env.REDIRECT_FROM_HOST}
 	}
 	handle @redirect_from_host {
 		redir {env.REDIRECT_TO_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -21,10 +21,10 @@
 	# Match only the specific redirect-from hostname from environment variable
 	# This ensures only the intended redirect-from URL is redirected, not main URLs
 	@redirect_from_host {
-		header Host {env.REDIRECT_FROM_HOST}
+		header Host {$REDIRECT_FROM_HOST}
 	}
 	handle @redirect_from_host {
-		redir {env.URL} permanent
+		redir {$URL} permanent
 	}
 
 	header {

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -21,10 +21,13 @@
 	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
 	# Only redirect if hostname doesn't contain "-frontend" and matches the redirect from pattern
 	# Redirects are logged in Caddy access logs with status 301
-	# Use expression matcher to check if hostname contains "-frontend" (more reliable than glob patterns)
+	# Match only URLs that match *.apps.silver.devops.gov.bc.ca but explicitly exclude *-frontend.apps.silver.devops.gov.bc.ca
+	# Using a more restrictive pattern to avoid catching main URLs
 	@redirect_from_host {
 		host *.apps.silver.devops.gov.bc.ca
-		expression `!http.request.host.contains("-frontend")`
+		not {
+			host *-frontend.apps.silver.devops.gov.bc.ca
+		}
 	}
 	handle @redirect_from_host {
 		redir {env.REDIRECT_TO_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -21,10 +21,10 @@
 	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
 	# Only redirect if hostname doesn't contain "-frontend" and matches the redirect from pattern
 	# Redirects are logged in Caddy access logs with status 301
-	# Use a more specific pattern to avoid matching main URLs
+	# Use expression matcher to check if hostname contains "-frontend" (more reliable than glob patterns)
 	@redirect_from_host {
 		host *.apps.silver.devops.gov.bc.ca
-		not host *-frontend*.apps.silver.devops.gov.bc.ca
+		expression `!http.request.host.contains("-frontend")`
 	}
 	handle @redirect_from_host {
 		redir {env.REDIRECT_TO_URL} permanent

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -17,20 +17,6 @@
 		level {$LOG_LEVEL}
 	}
 
-	# Redirect from URL format to main URL format
-	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
-	# Only redirect if hostname doesn't contain "-frontend" and matches the redirect from pattern
-	# Redirects are logged in Caddy access logs with status 301
-	# Use header matcher to check Host header and exclude URLs containing "-frontend"
-	# This is more reliable than glob patterns with 'not' directive
-	@redirect_from_host {
-		header Host *.apps.silver.devops.gov.bc.ca
-		not header Host *-frontend*.apps.silver.devops.gov.bc.ca
-	}
-	handle @redirect_from_host {
-		redir {env.REDIRECT_TO_URL} permanent
-	}
-
 	header {
 		# Security headers
 		X-Frame-Options "SAMEORIGIN"

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -20,6 +20,7 @@
 	# Redirect legacy URL format to main URL format
 	# Matches format: *-<number>.apps.silver.devops.gov.bc.ca (without -frontend suffix)
 	# Only redirect if hostname doesn't contain "-frontend" and matches the legacy pattern
+	# Redirects are logged in Caddy access logs with status 301
 	@legacy_host {
 		header Host *.apps.silver.devops.gov.bc.ca
 		expression `!{http.request.host}.contains("-frontend")`

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -48,6 +48,9 @@ parameters:
     value: "ca-central-1_t2HSZBHur"
   - name: VITE_ZONE
     value: PROD
+  - name: URL_LEGACY
+    description: Legacy URL for redirect (without -frontend suffix)
+    required: true
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update
     from: "[a-zA-Z0-9]{32}"
@@ -97,6 +100,8 @@ objects:
                   value: "${ZONE}"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
+                - name: REDIRECT_TARGET_URL
+                  value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
               ports:
                 - containerPort: 3000
                   protocol: TCP
@@ -149,6 +154,24 @@ objects:
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       host: "${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}"
+      port:
+        targetPort: 3000-tcp
+      to:
+        kind: Service
+        name: "${NAME}-${ZONE}-${COMPONENT}"
+        weight: 100
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${NAME}-${ZONE}-${COMPONENT}-legacy
+      labels:
+        app: ${NAME}-${ZONE}
+        purpose: url-redirect
+    spec:
+      host: "${URL_LEGACY}"
       port:
         targetPort: 3000-tcp
       to:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -48,8 +48,8 @@ parameters:
     value: "ca-central-1_t2HSZBHur"
   - name: VITE_ZONE
     value: PROD
-  - name: URL_LEGACY
-    description: Legacy URL for redirect (without -frontend suffix)
+  - name: REDIRECT_FROM_URL
+    description: Source URL for redirect (without -frontend suffix)
     required: true
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update
@@ -100,7 +100,7 @@ objects:
                   value: "${ZONE}"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
-                - name: REDIRECT_TARGET_URL
+                - name: REDIRECT_TO_URL
                   value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
               ports:
                 - containerPort: 3000
@@ -166,12 +166,12 @@ objects:
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:
-      name: ${NAME}-${ZONE}-${COMPONENT}-legacy
+      name: ${NAME}-${ZONE}-${COMPONENT}-redirect-from
       labels:
         app: ${NAME}-${ZONE}
         purpose: url-redirect
     spec:
-      host: "${URL_LEGACY}"
+      host: "${REDIRECT_FROM_URL}"
       port:
         targetPort: 3000-tcp
       to:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -102,6 +102,8 @@ objects:
                   value: ${RANDOM_EXPRESSION}
                 - name: REDIRECT_TO_URL
                   value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
+                - name: REDIRECT_FROM_HOST
+                  value: "${REDIRECT_FROM_URL}"
               ports:
                 - containerPort: 3000
                   protocol: TCP

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -49,7 +49,7 @@ parameters:
   - name: VITE_ZONE
     value: PROD
   - name: REDIRECT_FROM_URL
-    description: Source URL for redirect (without -frontend suffix)
+    description: URL for redirect
     required: true
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -100,7 +100,7 @@ objects:
                   value: "${ZONE}"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
-                - name: REDIRECT_TO_URL
+                - name: URL
                   value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
                 - name: REDIRECT_FROM_HOST
                   value: "${REDIRECT_FROM_URL}"

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -49,7 +49,7 @@ parameters:
   - name: VITE_ZONE
     value: PROD
   - name: REDIRECT_FROM_URL
-    description: URL for redirect
+    description: Hostname for the redirect-from URL (without protocol, e.g., nr-results-exam-12.apps.silver.devops.gov.bc.ca)
     required: true
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update

--- a/integration-tests/src/smoke.js
+++ b/integration-tests/src/smoke.js
@@ -165,7 +165,7 @@ const checks = [
     }
   },
   {
-    name: "legacy URL redirect",
+    name: "redirect from URL",
     url: frontendUrl.replace("-frontend", ""),
     validate: async (response) => {
       // This check is handled specially in executeCheck for redirect validation

--- a/integration-tests/src/smoke.js
+++ b/integration-tests/src/smoke.js
@@ -167,10 +167,7 @@ const checks = [
   {
     name: "redirect from URL",
     url: frontendUrl.replace("-frontend", ""),
-    validate: async (response) => {
-      // This check is handled specially in executeCheck for redirect validation
-      return true;
-    },
+    // Redirect validation is handled via checkRedirect in executeCheck
     checkRedirect: true,
     expectedRedirect: frontendUrl
   }


### PR DESCRIPTION
Add complete redirect infrastructure to redirect from URLs (without -frontend) to main URLs (with -frontend).

## Changes

- **Workflow**: Calculate both main URL (with -frontend) and redirect from URL (without -frontend) in init job
- **Workflow**: Pass REDIRECT_FROM_URL parameter to frontend deployment
- **Deployment**: Add REDIRECT_FROM_URL parameter (required) to frontend deployment template
- **Deployment**: Add REDIRECT_TO_URL environment variable set to main URL
- **Deployment**: Create redirect-from OpenShift Route for redirect from URL format
- **Caddy**: Add redirect logic using header matcher to exclude main URLs from redirect
- **Smoke Tests**: Add automated test to verify redirect functionality (301/308 status and Location header)
- **Documentation**: Update README with URL formats and redirect behavior

## Implementation Details

The redirect is implemented using Caddy's header matcher:
- Matches URLs ending with `*.apps.silver.devops.gov.bc.ca`
- Excludes URLs containing `-frontend` (e.g., `*-frontend.apps.silver.devops.gov.bc.ca`)
- Redirects matching requests with permanent redirect (301) to the main URL

## Impact

- Redirect from URLs (e.g., `nr-results-exam-3.apps...`) will redirect to main URLs (e.g., `nr-results-exam-3-frontend.apps...`)
- Main URL format unchanged - no breaking changes
- Redirect is permanent (301) for proper SEO and caching
- Header matcher ensures only redirect from URLs are redirected, not main URLs
- Both routes are functional during transition period

## Testing

Smoke tests verify:
1. Main URL (with -frontend) works normally
2. Redirect from URL (without -frontend) redirects (301/308) to main URL
3. Redirect Location header points to correct main URL

## Terminology

This PR uses "redirect from" and "redirect to" terminology instead of "legacy" to better describe the redirect direction and purpose.

## Notes

- This redirect infrastructure is temporary and will be removed after the transition period
- The main URL format (with `-frontend`) should be used for all new integrations and bookmarks

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-12-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-12.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-12-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)