### PR TITLE
fix: assign deployment failure issues to codeowners

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -124,7 +124,7 @@ jobs:
 
             // Read CODEOWNERS file to get assignees
             let assignees = [];
-            const codeownersPath = '${{ steps.find-codeowners.outputs.path }}';
+            const codeownersPath = `${{ steps.find-codeowners.outputs.path }}`.trim();
 
             if (codeownersPath) {
               try {
@@ -136,8 +136,10 @@ jobs:
                 
                 // Extract usernames from CODEOWNERS (format: * @username or path @username)
                 // Match both users (@username) and teams (@org/team-name)
-                // GitHub usernames can contain letters, numbers, hyphens, and underscores
-                const usernameMatches = lines.join('\n').match(/@([a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_-]+)?)/g);
+                // GitHub usernames must start/end with alphanumeric, can contain hyphens/underscores in middle
+                // NOTE: This intentionally extracts all usernames across all lines, regardless of path patterns.
+                // This ensures deployment failures are visible to all repository maintainers, not just path-specific owners.
+                const usernameMatches = lines.join('\n').match(/@([a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?(?:\/[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?)?)/g);
                 if (usernameMatches) {
                   // Remove '@', filter out team references (those containing '/')
                   // Teams cannot be assigned to issues, only individual users
@@ -170,5 +172,21 @@ jobs:
               });
               console.log(`Created issue #${issue.data.number} for deployment failure${assigneesToUse.length > 0 ? ` (assigned to: ${assigneesToUse.join(', ')})` : ''}`);
             } catch (error) {
-              core.error(`Could not create issue: ${error.message}`);
+              // If assignment fails due to permissions, retry without assignees but mention them
+              if (error.message && error.message.includes('assignees')) {
+                const bodyWithMentions = `${body}\n\ncc: ${assigneesToUse.map(u => `@${u}`).join(' ')}`;
+                try {
+                  const issue = await github.rest.issues.create({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    title: title,
+                    body: bodyWithMentions
+                  });
+                  console.log(`Created issue #${issue.data.number} (mentioned: ${assigneesToUse.join(', ')})`);
+                } catch (retryError) {
+                  core.error(`Could not create issue: ${retryError.message}`);
+                }
+              } else {
+                core.error(`Could not create issue: ${error.message}`);
+              }
             }

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -173,7 +173,7 @@ jobs:
               console.log(`Created issue #${issue.data.number} for deployment failure${assigneesToUse.length > 0 ? ` (assigned to: ${assigneesToUse.join(', ')})` : ''}`);
             } catch (error) {
               // If assignment fails due to permissions, retry without assignees but mention them
-              if (error.message && error.message.includes('assignees')) {
+              if (error.status === 422 || (error.response && error.response.status === 422)) {
                 const bodyWithMentions = `${body}\n\ncc: ${assigneesToUse.map(u => `@${u}`).join(' ')}`;
                 try {
                   const issue = await github.rest.issues.create({

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -135,10 +135,16 @@ jobs:
                   .filter(line => line && !line.startsWith('#'));
                 
                 // Extract usernames from CODEOWNERS (format: * @username or path @username)
+                // Match both users (@username) and teams (@org/team-name)
                 // GitHub usernames can contain letters, numbers, hyphens, and underscores
-                const usernameMatches = lines.join('\n').match(/@([a-zA-Z0-9_-]+)/g);
+                const usernameMatches = lines.join('\n').match(/@([a-zA-Z0-9_-]+(?:\/[a-zA-Z0-9_-]+)?)/g);
                 if (usernameMatches) {
-                  assignees = [...new Set(usernameMatches.map(m => m.substring(1)))];
+                  // Remove '@', filter out team references (those containing '/')
+                  // Teams cannot be assigned to issues, only individual users
+                  assignees = [...new Set(usernameMatches
+                    .map(m => m.substring(1))
+                    .filter(name => !name.includes('/'))
+                  )];
                 }
               } catch (error) {
                 console.log(`Could not read or parse CODEOWNERS: ${error.message}`);
@@ -147,15 +153,22 @@ jobs:
               console.log('No CODEOWNERS file found - issue will be created without assignees');
             }
 
+            // GitHub Issues API limits assignees to 10 per issue
+            const maxAssignees = 10;
+            const assigneesToUse = assignees.slice(0, maxAssignees);
+            if (assignees.length > maxAssignees) {
+              console.log(`Warning: ${assignees.length} assignees found, limiting to first ${maxAssignees}`);
+            }
+
             try {
               const issue = await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: title,
                 body: body,
-                assignees: assignees
+                assignees: assigneesToUse
               });
-              console.log(`Created issue #${issue.data.number} for deployment failure${assignees.length > 0 ? ` (assigned to: ${assignees.join(', ')})` : ''}`);
+              console.log(`Created issue #${issue.data.number} for deployment failure${assigneesToUse.length > 0 ? ` (assigned to: ${assigneesToUse.join(', ')})` : ''}`);
             } catch (error) {
               core.error(`Could not create issue: ${error.message}`);
             }

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -80,24 +80,46 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       issues: write
+      contents: read
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      
       - name: Report Results
         uses: actions/github-script@v8
         with:
           script: |
+            const fs = require('fs');
             const zone = '${{ inputs.zone }}';
             const workflowUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const title = `Deployment failed: ${zone} (Run #${context.runId})`;
             const body = `❌ Deployment to **${zone}** zone failed.\n\n[View workflow run](${workflowUrl})`;
+
+            // Read CODEOWNERS file to get assignees
+            let assignees = [];
+            try {
+              const codeownersPath = '.github/CODEOWNERS';
+              if (fs.existsSync(codeownersPath)) {
+                const codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
+                // Extract usernames from CODEOWNERS (format: * @username or path @username)
+                const usernameMatches = codeownersContent.match(/@(\w+)/g);
+                if (usernameMatches) {
+                  assignees = [...new Set(usernameMatches.map(m => m.substring(1)))];
+                }
+              }
+            } catch (error) {
+              console.log(`Could not read CODEOWNERS: ${error.message}`);
+            }
 
             try {
               const issue = await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: title,
-                body: body
+                body: body,
+                assignees: assignees
               });
-              console.log(`Created issue #${issue.data.number} for deployment failure`);
+              console.log(`Created issue #${issue.data.number} for deployment failure${assignees.length > 0 ? ` (assigned to: ${assignees.join(', ')})` : ''}`);
             } catch (error) {
               core.error(`Could not create issue: ${error.message}`);
             }

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      
+
       - name: Report Results
         uses: actions/github-script@v8
         with:
@@ -92,7 +92,7 @@ jobs:
             const fs = require('fs');
             const zone = '${{ inputs.zone }}';
             const workflowUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const title = `Deployment failed: ${zone} (Run #${context.runId})`;
+            const title = `ci(deploy): deployment failed in ${zone}`;
             const body = `❌ Deployment to **${zone}** zone failed.\n\n[View workflow run](${workflowUrl})`;
 
             // Read CODEOWNERS file to get assignees

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -84,6 +84,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1  # Shallow clone since we only need CODEOWNERS
 
       - name: Report Results
         uses: actions/github-script@v8
@@ -101,8 +103,14 @@ jobs:
               const codeownersPath = '.github/CODEOWNERS';
               if (fs.existsSync(codeownersPath)) {
                 const codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
+                // Filter out comment lines (lines starting with #) and empty lines
+                const lines = codeownersContent.split('\n')
+                  .map(line => line.trim())
+                  .filter(line => line && !line.startsWith('#'));
+                
                 // Extract usernames from CODEOWNERS (format: * @username or path @username)
-                const usernameMatches = codeownersContent.match(/@(\w+)/g);
+                // GitHub usernames can contain letters, numbers, hyphens, and underscores
+                const usernameMatches = lines.join('\n').match(/@([a-zA-Z0-9_-]+)/g);
                 if (usernameMatches) {
                   assignees = [...new Set(usernameMatches.map(m => m.substring(1)))];
                 }

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1  # Shallow clone since we only need CODEOWNERS
+          fetch-depth: 1 # Shallow clone since we only need CODEOWNERS
 
       - name: Report Results
         uses: actions/github-script@v8
@@ -98,11 +98,31 @@ jobs:
             const body = `❌ Deployment to **${zone}** zone failed.\n\n[View workflow run](${workflowUrl})`;
 
             // Read CODEOWNERS file to get assignees
+            // Check common CODEOWNERS locations (in order of precedence)
+            const codeownersPaths = [
+              '.github/CODEOWNERS',  // Most common location
+              'CODEOWNERS',          // Root of repository
+              'docs/CODEOWNERS'      // Sometimes in docs
+            ];
+            
             let assignees = [];
-            try {
-              const codeownersPath = '.github/CODEOWNERS';
-              if (fs.existsSync(codeownersPath)) {
-                const codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
+            let codeownersContent = null;
+            
+            for (const codeownersPath of codeownersPaths) {
+              try {
+                if (fs.existsSync(codeownersPath)) {
+                  codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
+                  console.log(`Found CODEOWNERS at: ${codeownersPath}`);
+                  break;
+                }
+              } catch (error) {
+                // Continue to next path
+                continue;
+              }
+            }
+            
+            if (codeownersContent) {
+              try {
                 // Filter out comment lines (lines starting with #) and empty lines
                 const lines = codeownersContent.split('\n')
                   .map(line => line.trim())
@@ -114,9 +134,9 @@ jobs:
                 if (usernameMatches) {
                   assignees = [...new Set(usernameMatches.map(m => m.substring(1)))];
                 }
+              } catch (error) {
+                console.log(`Could not parse CODEOWNERS: ${error.message}`);
               }
-            } catch (error) {
-              console.log(`Could not read CODEOWNERS: ${error.message}`);
             }
 
             try {

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -90,11 +90,20 @@ jobs:
       - name: Find CODEOWNERS file
         id: find-codeowners
         run: |
-          # Find CODEOWNERS file case-insensitively, prefer .github/CODEOWNERS
-          # First try .github/ directory, then search everywhere
-          CODEOWNERS_PATH=$(find .github -type f -iname "codeowners*" 2>/dev/null | head -1)
+          # Find CODEOWNERS file case-insensitively in GitHub-recognized locations
+          # GitHub searches in order: root, .github/, docs/ (use first found)
+          CODEOWNERS_PATH=""
+          # Check root first
           if [ -z "$CODEOWNERS_PATH" ]; then
-            CODEOWNERS_PATH=$(find . -type f -iname "codeowners*" -not -path "*/\.git/*" | head -1)
+            CODEOWNERS_PATH=$(find . -maxdepth 1 -type f -iname "codeowners*" -not -path "*/\.git/*" 2>/dev/null | head -1)
+          fi
+          # Then .github/
+          if [ -z "$CODEOWNERS_PATH" ]; then
+            CODEOWNERS_PATH=$(find .github -maxdepth 1 -type f -iname "codeowners*" 2>/dev/null | head -1)
+          fi
+          # Finally docs/
+          if [ -z "$CODEOWNERS_PATH" ]; then
+            CODEOWNERS_PATH=$(find docs -maxdepth 1 -type f -iname "codeowners*" 2>/dev/null | head -1)
           fi
           if [ -n "$CODEOWNERS_PATH" ]; then
             echo "path=$CODEOWNERS_PATH" >> $GITHUB_OUTPUT

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -98,29 +98,42 @@ jobs:
             const body = `❌ Deployment to **${zone}** zone failed.\n\n[View workflow run](${workflowUrl})`;
 
             // Read CODEOWNERS file to get assignees
-            // Check common CODEOWNERS locations (in order of precedence)
-            const codeownersPaths = [
-              '.github/CODEOWNERS',  // Most common location
-              'CODEOWNERS',          // Root of repository
-              'docs/CODEOWNERS'      // Sometimes in docs
+            // Check common CODEOWNERS locations and case variations
+            // GitHub officially uses "CODEOWNERS" (all caps), but check variations for robustness
+            const codeownersBasePaths = [
+              '.github/',  // Most common location
+              '',          // Root of repository
+              'docs/'      // Sometimes in docs
+            ];
+            
+            const codeownersFilenames = [
+              'CODEOWNERS',    // Official (all caps)
+              'codeowners',    // Lowercase
+              'CodeOwners',    // Mixed case
+              'codeowners.txt' // With extension (less common)
             ];
             
             let assignees = [];
             let codeownersContent = null;
             
-            for (const codeownersPath of codeownersPaths) {
-              try {
-                if (fs.existsSync(codeownersPath)) {
-                  codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
-                  console.log(`Found CODEOWNERS at: ${codeownersPath}`);
-                  break;
+            // Check each base path with each filename variation
+            for (const basePath of codeownersBasePaths) {
+              for (const filename of codeownersFilenames) {
+                const codeownersPath = basePath + filename;
+                try {
+                  if (fs.existsSync(codeownersPath)) {
+                    codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
+                    console.log(`Found CODEOWNERS at: ${codeownersPath}`);
+                    break;
+                  }
+                } catch (error) {
+                  // Continue to next path/filename combination
+                  continue;
                 }
-              } catch (error) {
-                // Continue to next path
-                continue;
               }
+              if (codeownersContent) break; // Found file, stop searching
             }
-            
+
             if (codeownersContent) {
               try {
                 // Filter out comment lines (lines starting with #) and empty lines

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -105,17 +105,17 @@ jobs:
               '',          // Root of repository
               'docs/'      // Sometimes in docs
             ];
-            
+
             const codeownersFilenames = [
               'CODEOWNERS',    // Official (all caps)
               'codeowners',    // Lowercase
               'CodeOwners',    // Mixed case
               'codeowners.txt' // With extension (less common)
             ];
-            
+
             let assignees = [];
             let codeownersContent = null;
-            
+
             // Check each base path with each filename variation
             for (const basePath of codeownersBasePaths) {
               for (const filename of codeownersFilenames) {

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -134,6 +134,8 @@ jobs:
               } catch (error) {
                 console.log(`Could not read or parse CODEOWNERS: ${error.message}`);
               }
+            } else {
+              console.log('No CODEOWNERS file found - issue will be created without assignees');
             }
 
             try {

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -87,6 +87,22 @@ jobs:
         with:
           fetch-depth: 1 # Shallow clone since we only need CODEOWNERS
 
+      - name: Find CODEOWNERS file
+        id: find-codeowners
+        run: |
+          # Find CODEOWNERS file case-insensitively, prefer .github/CODEOWNERS
+          # First try .github/ directory, then search everywhere
+          CODEOWNERS_PATH=$(find .github -type f -iname "codeowners*" 2>/dev/null | head -1)
+          if [ -z "$CODEOWNERS_PATH" ]; then
+            CODEOWNERS_PATH=$(find . -type f -iname "codeowners*" -not -path "*/\.git/*" | head -1)
+          fi
+          if [ -n "$CODEOWNERS_PATH" ]; then
+            echo "path=$CODEOWNERS_PATH" >> $GITHUB_OUTPUT
+            echo "Found CODEOWNERS at: $CODEOWNERS_PATH"
+          else
+            echo "No CODEOWNERS file found"
+          fi
+
       - name: Report Results
         uses: actions/github-script@v8
         with:
@@ -98,44 +114,12 @@ jobs:
             const body = `❌ Deployment to **${zone}** zone failed.\n\n[View workflow run](${workflowUrl})`;
 
             // Read CODEOWNERS file to get assignees
-            // Check common CODEOWNERS locations and case variations
-            // GitHub officially uses "CODEOWNERS" (all caps), but check variations for robustness
-            const codeownersBasePaths = [
-              '.github/',  // Most common location
-              '',          // Root of repository
-              'docs/'      // Sometimes in docs
-            ];
-
-            const codeownersFilenames = [
-              'CODEOWNERS',    // Official (all caps)
-              'codeowners',    // Lowercase
-              'CodeOwners',    // Mixed case
-              'codeowners.txt' // With extension (less common)
-            ];
-
             let assignees = [];
-            let codeownersContent = null;
+            const codeownersPath = '${{ steps.find-codeowners.outputs.path }}';
 
-            // Check each base path with each filename variation
-            for (const basePath of codeownersBasePaths) {
-              for (const filename of codeownersFilenames) {
-                const codeownersPath = basePath + filename;
-                try {
-                  if (fs.existsSync(codeownersPath)) {
-                    codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
-                    console.log(`Found CODEOWNERS at: ${codeownersPath}`);
-                    break;
-                  }
-                } catch (error) {
-                  // Continue to next path/filename combination
-                  continue;
-                }
-              }
-              if (codeownersContent) break; // Found file, stop searching
-            }
-
-            if (codeownersContent) {
+            if (codeownersPath) {
               try {
+                const codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
                 // Filter out comment lines (lines starting with #) and empty lines
                 const lines = codeownersContent.split('\n')
                   .map(line => line.trim())
@@ -148,7 +132,7 @@ jobs:
                   assignees = [...new Set(usernameMatches.map(m => m.substring(1)))];
                 }
               } catch (error) {
-                console.log(`Could not parse CODEOWNERS: ${error.message}`);
+                console.log(`Could not read or parse CODEOWNERS: ${error.message}`);
               }
             }
 


### PR DESCRIPTION
## Description

Fixes issues with deployment failure reporting:
1. Issues are now assigned to codeowners (from CODEOWNERS file) so they receive notifications
2. Issue titles now use conventional commits format: `ci(deploy): deployment failed in {zone}`

Fixes #478

## Changes

- Add checkout step to read CODEOWNERS file
- Parse CODEOWNERS to extract usernames and assign to issues
- Update issue title to use conventional commits format: `ci(deploy): deployment failed in {zone}`
- Add `contents: read` permission to read CODEOWNERS file

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] YAML syntax validation
- [x] Workflow logic verified

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have used conventional commits format for commit messages

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-29-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-29.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-29-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)