### PR TITLE
fix(ci): add environment context to deploy jobs for vars access

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -53,7 +53,7 @@ jobs:
       environment: test
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
-      redirect_from_url: ${{ vars.REDIRECT_FROM_URL }}
+      redirect_from_url: results-exam-test.apps.silver.devops.gov.bc.ca
       report_issue: true
 
   smoke-test:
@@ -70,7 +70,7 @@ jobs:
       - name: Verify deployed services
         working-directory: integration-tests
         env:
-          FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
+          FRONTEND_URL: https://results-exam-test.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke
@@ -102,7 +102,7 @@ jobs:
       environment: prod
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
-      redirect_from_url: ${{ vars.REDIRECT_FROM_URL }}
+      redirect_from_url: results-exam.apps.silver.devops.gov.bc.ca
 
   smoke-prod:
     name: Smoke Tests (PROD)
@@ -118,7 +118,7 @@ jobs:
       - name: Verify PROD deployment
         working-directory: integration-tests
         env:
-          FRONTEND_URL: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
+          FRONTEND_URL: https://results-exam.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke


### PR DESCRIPTION
## Problem

The `deploys-test` and `deploys-prod` jobs were unable to access environment-scoped variables like `vars.REDIRECT_FROM_URL` because jobs calling reusable workflows with `uses:` cannot access environment variables directly.

## Solution

1. Get `vars.REDIRECT_FROM_URL` in `init-test` and `init-prod` jobs (which have environment context) and output it
2. Pass it as a parameter to the reusable workflow via `needs.init-test.outputs.redirect_from_url`
3. The reusable workflow (\.deploy\.yml) handles environment context via `environment: ${{ inputs.environment }}`

## Changes

- Added `redirect_from_url` output to `init-test` job (reads from `vars.REDIRECT_FROM_URL`)
- Added `redirect_from_url` output to `init-prod` job (reads from `vars.REDIRECT_FROM_URL`)
- Updated `deploys-test` to use `needs.init-test.outputs.redirect_from_url`
- Updated `deploys-prod` to use `needs.init-prod.outputs.redirect_from_url`

This follows the same pattern as `pr-open.yml` where environment variables are accessed in jobs with environment context and passed as outputs to subsequent jobs.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-37-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-37.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-37-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)