### PR TITLE
chore(ci): fix smoke test failures in merge workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Verify deployed services
         working-directory: integration-tests
         env:
-          FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca/
+          FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Verify deployed services
         working-directory: integration-tests
         env:
-          FRONTEND_URL: https://results-exam-test.apps.silver.devops.gov.bc.ca
+          FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca/
         run: |
           npm ci
           npm run smoke
@@ -118,7 +118,7 @@ jobs:
       - name: Verify PROD deployment
         working-directory: integration-tests
         env:
-          FRONTEND_URL: https://results-exam.apps.silver.devops.gov.bc.ca
+          FRONTEND_URL: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke


### PR DESCRIPTION
Looks like using the redirect URLs failed.  Trying full URLs.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-38-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-38.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-38-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)