### PR TITLE
chore(ci): fix smoke tests

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: integration-tests
         env:
           FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
-          REDIRECT_FROM_URL: results-exam-test.apps.silver.devops.gov.bc.ca
+          REDIRECT_FROM_URL: https://results-exam-test.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke
@@ -120,7 +120,7 @@ jobs:
         working-directory: integration-tests
         env:
           FRONTEND_URL: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
-          REDIRECT_FROM_URL: results-exam.apps.silver.devops.gov.bc.ca
+          REDIRECT_FROM_URL: https://results-exam.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -71,6 +71,7 @@ jobs:
         working-directory: integration-tests
         env:
           FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
+          REDIRECT_FROM_URL: results-exam-test.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke
@@ -119,6 +120,7 @@ jobs:
         working-directory: integration-tests
         env:
           FRONTEND_URL: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
+          REDIRECT_FROM_URL: results-exam.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke

--- a/integration-tests/src/smoke.js
+++ b/integration-tests/src/smoke.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 const frontendUrl = process.env.FRONTEND_URL?.replace(/\/$/, "") ?? "http://localhost:3000";
+const redirectFromUrl = process.env.REDIRECT_FROM_URL?.replace(/\/$/, "");
 const origin = process.env.SMOKE_ORIGIN ?? frontendUrl;
 const DEFAULT_TIMEOUT_MS = 5000;
 const MIN_TIMEOUT_MS = 1000;
@@ -164,13 +165,13 @@ const checks = [
       return response.status === 200;
     }
   },
-  {
+  // Only add redirect check if REDIRECT_FROM_URL is configured
+  ...(redirectFromUrl ? [{
     name: "redirect from URL",
-    url: frontendUrl.replace("-frontend", ""),
-    // Redirect validation is handled via checkRedirect in executeCheck
+    url: redirectFromUrl,
     checkRedirect: true,
     expectedRedirect: frontendUrl
-  }
+  }] : [])
 ];
 
 const validateRedirectLocation = (location, expectedRedirect) => {


### PR DESCRIPTION
## Problem

The smoke tests were checking a redirect URL that was programmatically derived by removing `-frontend` from the frontend URL. This assumes a pattern and isn't valuable since the redirect URL should be completely end-user configurable.

## Solution

Add redirect URL check to smoke tests using a configurable `REDIRECT_FROM_URL` environment variable instead of deriving it. The redirect check is only included if `REDIRECT_FROM_URL` is set, making it optional and configurable.

## Changes

- Added `redirectFromUrl` variable that reads from `process.env.REDIRECT_FROM_URL`
- Added redirect check conditionally to checks array (only if `REDIRECT_FROM_URL` is set)
- Restored `validateRedirectLocation` function
- Restored redirect handling logic in `executeCheck`
- Added `REDIRECT_FROM_URL` environment variable to `smoke-test` and `smoke-prod` jobs in merge workflow

## Testing

The redirect check will now run when `REDIRECT_FROM_URL` is set in the workflow. The values match the `redirect_from_url` values passed to the deploy jobs:
- TEST: `results-exam-test.apps.silver.devops.gov.bc.ca`
- PROD: `results-exam.apps.silver.devops.gov.bc.ca`

This ensures the redirect functionality is tested when deployed, and keeps the code and tests in sync. When redirect functionality is removed from k8s templates, both the template code and test code should be removed together.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-39-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-39.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-39-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)