### PR TITLE
chore: consolidate duplicate init and smoke test jobs into .deploy.yml

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -97,7 +97,7 @@ jobs:
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
 
   report-failures:
-    name: Deployment Results
+    name: Failure Reporting
     if: ${{ inputs.report_issue && always() && failure() }}
     # Include all needs that could have failures!
     needs: [init, deploys]

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -22,10 +22,10 @@ on:
         description: GitHub/OpenShift environment; usually PR number, test or prod
         default: ""
         type: string
-      report_issue:
-        description: Create an issue when deployment fails
-        default: false
-        type: boolean
+      pr_number:
+        description: PR number if this is a PR deployment (empty for non-PRs)
+        required: false
+        type: string
       frontend_url:
         description: Frontend URL for smoke tests (auto-calculated if not provided)
         required: false
@@ -138,8 +138,9 @@ jobs:
 
   report-failures:
     name: Failure Reporting
-    if: ${{ inputs.report_issue && always() && (needs.init.result == 'failure' || needs.deploys.result == 'failure' || needs.smoke.result == 'failure') }}
-    # Include all needs that could have failures!
+    if: failure() && !inputs.pr_number
+    # Create issues for non-PR deployments (test/prod)
+    # PRs don't need issues since failures are visible in the PR checks
     needs: [init, deploys, smoke]
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       ### Required
-      redirect_from_url:
+      redirect_url:
         description: Frontend redirect from URL
         required: true
         type: string
@@ -94,7 +94,7 @@ jobs:
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
             -p MOD_ZONE=${{ needs.init.outputs.mod_zone }}
-            ${{ matrix.name == 'frontend' && format('-p REDIRECT_FROM_URL={0}', inputs.redirect_from_url) || '' }}
+            ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
 
   report-failures:
     name: Deployment Results

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -127,7 +127,7 @@ jobs:
           fi
 
       - uses: actions/checkout@v6
-      
+
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -26,6 +26,14 @@ on:
         description: Create an issue when deployment fails
         default: false
         type: boolean
+      run_smoke_tests:
+        description: Run smoke tests after deployment
+        default: true
+        type: boolean
+      frontend_url:
+        description: Frontend URL for smoke tests (auto-calculated if not provided)
+        required: false
+        type: string
 
     secrets:
       ches_client_secret:
@@ -96,11 +104,50 @@ jobs:
             -p MOD_ZONE=${{ needs.init.outputs.mod_zone }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
 
+  smoke:
+    name: Smoke Tests
+    if: inputs.run_smoke_tests == true
+    needs: [init, deploys]
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Calculate frontend URL
+        id: frontend-url
+        run: |
+          if [ -n "${{ inputs.frontend_url }}" ]; then
+            # Use provided frontend URL
+            echo "url=${{ inputs.frontend_url }}" >> $GITHUB_OUTPUT
+          else
+            # Calculate from zone (for PRs)
+            DOMAIN="apps.silver.devops.gov.bc.ca"
+            REPO="nr-results-exam"
+            MOD_ZONE="${{ needs.init.outputs.mod_zone }}"
+            echo "url=https://${REPO}-${MOD_ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v6
+      
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Run smoke tests
+        working-directory: integration-tests
+        env:
+          FRONTEND_URL: ${{ steps.frontend-url.outputs.url }}
+          REDIRECT_URL: ${{ inputs.redirect_url && format('https://{0}', inputs.redirect_url) || '' }}
+        run: |
+          npm ci
+          npm run smoke
+
   report-failures:
     name: Failure Reporting
-    if: ${{ inputs.report_issue && always() && failure() }}
+    if: ${{ inputs.report_issue && always() && (needs.init.result == 'failure' || needs.deploys.result == 'failure' || (inputs.run_smoke_tests && needs.smoke.result == 'failure')) }}
     # Include all needs that could have failures!
-    needs: [init, deploys]
+    # Note: smoke is conditional - if skipped, report-failures will also be skipped
+    # but we check smoke result only if run_smoke_tests is true
+    needs: [init, deploys, smoke]
     runs-on: ubuntu-24.04
     permissions:
       issues: write

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -26,10 +26,6 @@ on:
         description: Create an issue when deployment fails
         default: false
         type: boolean
-      vite_user_pools_web_client_id:
-        description: VITE_USER_POOLS_WEB_CLIENT_ID variable
-        required: true
-        type: string
 
     secrets:
       ches_client_secret:
@@ -63,7 +59,7 @@ jobs:
           parameters: -p ZONE=${{ inputs.zone }}
             -p CHES_CLIENT_SECRET=${{ secrets.ches_client_secret }}
             -p S3_SECRETKEY=${{ secrets.s3_secretkey }}
-            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ inputs.vite_user_pools_web_client_id }}
+            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
       - name: Calculate MOD_ZONE
         id: mod-zone

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -28,7 +28,7 @@ on:
         type: boolean
       vite_user_pools_web_client_id:
         description: VITE_USER_POOLS_WEB_CLIENT_ID variable
-        required: false
+        required: true
         type: string
 
     secrets:
@@ -63,7 +63,7 @@ jobs:
           parameters: -p ZONE=${{ inputs.zone }}
             -p CHES_CLIENT_SECRET=${{ secrets.ches_client_secret }}
             -p S3_SECRETKEY=${{ secrets.s3_secretkey }}
-            ${{ inputs.vite_user_pools_web_client_id && format('-p VITE_USER_POOLS_WEB_CLIENT_ID={0}', inputs.vite_user_pools_web_client_id) || '' }}
+            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ inputs.vite_user_pools_web_client_id }}
 
       - name: Calculate MOD_ZONE
         id: mod-zone

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -26,10 +26,6 @@ on:
         description: Create an issue when deployment fails
         default: false
         type: boolean
-      run_smoke_tests:
-        description: Run smoke tests after deployment
-        default: true
-        type: boolean
       frontend_url:
         description: Frontend URL for smoke tests (auto-calculated if not provided)
         required: false
@@ -106,7 +102,6 @@ jobs:
 
   smoke:
     name: Smoke Tests
-    if: inputs.run_smoke_tests == true
     needs: [init, deploys]
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
@@ -143,10 +138,8 @@ jobs:
 
   report-failures:
     name: Failure Reporting
-    if: ${{ inputs.report_issue && always() && (needs.init.result == 'failure' || needs.deploys.result == 'failure' || (inputs.run_smoke_tests && needs.smoke.result == 'failure')) }}
+    if: ${{ inputs.report_issue && always() && (needs.init.result == 'failure' || needs.deploys.result == 'failure' || needs.smoke.result == 'failure') }}
     # Include all needs that could have failures!
-    # Note: smoke is conditional - if skipped, report-failures will also be skipped
-    # but we check smoke result only if run_smoke_tests is true
     needs: [init, deploys, smoke]
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -26,10 +26,26 @@ on:
         description: Create an issue when deployment fails
         default: false
         type: boolean
+      vite_user_pools_web_client_id:
+        description: VITE_USER_POOLS_WEB_CLIENT_ID variable
+        required: false
+        type: string
+
+    secrets:
+      ches_client_secret:
+        description: CHES client secret
+        required: true
+      oc_token:
+        description: OpenShift token
+        required: true
+      s3_secretkey:
+        description: S3 secret key
+        required: true
 
 jobs:
   init:
-    name: Calculate deployment parameters
+    name: Init and calculate deployment parameters
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     permissions:
@@ -37,6 +53,18 @@ jobs:
     outputs:
       mod_zone: ${{ steps.mod-zone.outputs.mod_zone }}
     steps:
+      - name: Deploy OpenShift init resources
+        uses: bcgov/action-deployer-openshift@v4.0.1
+        with:
+          file: common/openshift.init.yml
+          oc_namespace: ${{ vars.OC_NAMESPACE }}
+          oc_server: ${{ vars.OC_SERVER }}
+          oc_token: ${{ secrets.oc_token }}
+          parameters: -p ZONE=${{ inputs.zone }}
+            -p CHES_CLIENT_SECRET=${{ secrets.ches_client_secret }}
+            -p S3_SECRETKEY=${{ secrets.s3_secretkey }}
+            ${{ inputs.vite_user_pools_web_client_id && format('-p VITE_USER_POOLS_WEB_CLIENT_ID={0}', inputs.vite_user_pools_web_client_id) || '' }}
+
       - name: Calculate MOD_ZONE
         id: mod-zone
         run: |
@@ -66,7 +94,7 @@ jobs:
           file: ${{ matrix.name }}/openshift.deploy.yml
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
-          oc_token: ${{ secrets.OC_TOKEN }}
+          oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
             -p MOD_ZONE=${{ needs.init.outputs.mod_zone }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,7 +39,6 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
       redirect_url: results-exam-test.apps.silver.devops.gov.bc.ca
-      report_issue: true
       frontend_url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
 
   deploys-prod:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -40,30 +40,11 @@ jobs:
       zone: test
       redirect_url: results-exam-test.apps.silver.devops.gov.bc.ca
       report_issue: true
-
-  smoke-test:
-    name: Smoke Tests (TEST)
-    needs: [vars, deploys-test]
-    environment: test
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-      - name: Verify deployed services
-        working-directory: integration-tests
-        env:
-          FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
-          REDIRECT_URL: https://results-exam-test.apps.silver.devops.gov.bc.ca
-        run: |
-          npm ci
-          npm run smoke
+      frontend_url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
 
   deploys-prod:
     name: Deploys (PROD)
-    needs: [vars, smoke-test]
+    needs: [vars, deploys-test]
     uses: ./.github/workflows/.deploy.yml
     secrets:
       ches_client_secret: ${{ secrets.CHES_CLIENT_SECRET }}
@@ -74,30 +55,11 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
       redirect_url: results-exam.apps.silver.devops.gov.bc.ca
-
-  smoke-prod:
-    name: Smoke Tests (PROD)
-    needs: [vars, deploys-prod]
-    environment: prod
-    runs-on: ubuntu-24.04
-    timeout-minutes: 3
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-      - name: Verify PROD deployment
-        working-directory: integration-tests
-        env:
-          FRONTEND_URL: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
-          REDIRECT_URL: https://results-exam.apps.silver.devops.gov.bc.ca
-        run: |
-          npm ci
-          npm run smoke
+      frontend_url: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
 
   image-promotions:
     name: Promote images
-    needs: [vars, smoke-prod]
+    needs: [vars, deploys-prod]
     permissions:
       packages: write
     runs-on: ubuntu-24.04

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -26,35 +26,21 @@ jobs:
         id: pr
         uses: bcgov/action-get-pr@v0.0.1
 
-  init-test:
-    name: Init (TEST)
-    needs: vars
-    environment: test
-    runs-on: ubuntu-24.04
-    timeout-minutes: 1
-    steps:
-      - uses: bcgov/action-deployer-openshift@v4.0.1
-        with:
-          file: common/openshift.init.yml
-          oc_namespace: ${{ vars.OC_NAMESPACE }}
-          oc_server: ${{ vars.OC_SERVER }}
-          oc_token: ${{ secrets.OC_TOKEN }}
-          parameters: -p ZONE=test
-            -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
-            -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
-            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
-
   deploys-test:
     name: Deploys (TEST)
-    needs: [vars, init-test]
+    needs: [vars]
     uses: ./.github/workflows/.deploy.yml
-    secrets: inherit
+    secrets:
+      ches_client_secret: ${{ secrets.CHES_CLIENT_SECRET }}
+      oc_token: ${{ secrets.OC_TOKEN }}
+      s3_secretkey: ${{ secrets.S3_SECRETKEY }}
     with:
       environment: test
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
       redirect_from_url: results-exam-test.apps.silver.devops.gov.bc.ca
       report_issue: true
+      vite_user_pools_web_client_id: ${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
   smoke-test:
     name: Smoke Tests (TEST)
@@ -76,34 +62,20 @@ jobs:
           npm ci
           npm run smoke
 
-  init-prod:
-    name: Init (PROD)
-    needs: [vars, smoke-test]
-    environment: prod
-    runs-on: ubuntu-24.04
-    timeout-minutes: 1
-    steps:
-      - uses: bcgov/action-deployer-openshift@v4.0.1
-        with:
-          file: common/openshift.init.yml
-          oc_namespace: ${{ vars.OC_NAMESPACE }}
-          oc_server: ${{ vars.OC_SERVER }}
-          oc_token: ${{ secrets.OC_TOKEN }}
-          parameters: -p ZONE=prod
-            -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
-            -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
-            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
-
   deploys-prod:
     name: Deploys (PROD)
-    needs: [vars, init-prod]
+    needs: [vars, smoke-test]
     uses: ./.github/workflows/.deploy.yml
-    secrets: inherit
+    secrets:
+      ches_client_secret: ${{ secrets.CHES_CLIENT_SECRET }}
+      oc_token: ${{ secrets.OC_TOKEN }}
+      s3_secretkey: ${{ secrets.S3_SECRETKEY }}
     with:
       environment: prod
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
       redirect_from_url: results-exam.apps.silver.devops.gov.bc.ca
+      vite_user_pools_web_client_id: ${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
   smoke-prod:
     name: Smoke Tests (PROD)

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -38,7 +38,7 @@ jobs:
       environment: test
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
-      redirect_from_url: results-exam-test.apps.silver.devops.gov.bc.ca
+      redirect_url: results-exam-test.apps.silver.devops.gov.bc.ca
       report_issue: true
 
   smoke-test:
@@ -56,7 +56,7 @@ jobs:
         working-directory: integration-tests
         env:
           FRONTEND_URL: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
-          REDIRECT_FROM_URL: https://results-exam-test.apps.silver.devops.gov.bc.ca
+          REDIRECT_URL: https://results-exam-test.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke
@@ -73,7 +73,7 @@ jobs:
       environment: prod
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
-      redirect_from_url: results-exam.apps.silver.devops.gov.bc.ca
+      redirect_url: results-exam.apps.silver.devops.gov.bc.ca
 
   smoke-prod:
     name: Smoke Tests (PROD)
@@ -90,7 +90,7 @@ jobs:
         working-directory: integration-tests
         env:
           FRONTEND_URL: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
-          REDIRECT_FROM_URL: https://results-exam.apps.silver.devops.gov.bc.ca
+          REDIRECT_URL: https://results-exam.apps.silver.devops.gov.bc.ca
         run: |
           npm ci
           npm run smoke

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -40,7 +40,6 @@ jobs:
       zone: test
       redirect_from_url: results-exam-test.apps.silver.devops.gov.bc.ca
       report_issue: true
-      vite_user_pools_web_client_id: ${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
   smoke-test:
     name: Smoke Tests (TEST)
@@ -75,7 +74,6 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
       redirect_from_url: results-exam.apps.silver.devops.gov.bc.ca
-      vite_user_pools_web_client_id: ${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
   smoke-prod:
     name: Smoke Tests (PROD)

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -57,7 +57,6 @@ jobs:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
       redirect_from_url: ${{ needs.vars.outputs.redirect_from_url }}
-      vite_user_pools_web_client_id: ${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
   smoke:
     name: Smoke Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -58,29 +58,12 @@ jobs:
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
 
-  smoke:
-    name: Smoke Tests
-    needs: [deploys]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 3
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
-      - name: Run smoke checks against PR deployment
-        working-directory: integration-tests
-        run: |
-          npm ci
-          export FRONTEND_URL="https://nr-results-exam-$(( ${{ github.event.number }} % 50 ))-frontend.apps.silver.devops.gov.bc.ca"
-          npm run smoke
-
   results:
     name: PR Results
     if: always() && !failure()
     # Include all needs that could have failures!
-    needs: [builds, deploys, smoke]
+    # Note: deploys now includes smoke tests
+    needs: [builds, deploys]
     runs-on: ubuntu-24.04
     steps:
       - run: echo "Workflow completed successfully!"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -29,46 +29,35 @@ jobs:
           tag_fallback: latest
           triggers: ('${{ matrix.triggers }}/')
 
-  # https://github.com/bcgov/action-deployer-openshift
-  init:
-    name: Init
+  vars:
+    name: Variables
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     outputs:
-      url: ${{ steps.url.outputs.url }}
       redirect_from_url: ${{ steps.url.outputs.redirect_from_url }}
     steps:
-      - uses: bcgov/action-deployer-openshift@v4.0.1
-        with:
-          file: common/openshift.init.yml
-          oc_namespace: ${{ vars.OC_NAMESPACE }}
-          oc_server: ${{ vars.OC_SERVER }}
-          oc_token: ${{ secrets.OC_TOKEN }}
-          parameters: -p ZONE=${{ github.event.number }}
-            -p CHES_CLIENT_SECRET=${{ secrets.CHES_CLIENT_SECRET }}
-            -p S3_SECRETKEY=${{ secrets.S3_SECRETKEY }}
-            -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
-
-      - name: Calculate URLs
+      - name: Calculate redirect_from_url
         id: url
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
           REPO="${{ github.event.repository.name }}"
           ZONE="$(( ${{ github.event.number }} % 50 ))"
-          # Main URL (with -frontend) - current working format
-          echo "url=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
           # Redirect from URL (without -frontend) - will redirect to main
           echo "redirect_from_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
-    needs: [builds, init]
+    needs: [builds, vars]
     uses: ./.github/workflows/.deploy.yml
-    secrets: inherit
+    secrets:
+      ches_client_secret: ${{ secrets.CHES_CLIENT_SECRET }}
+      oc_token: ${{ secrets.OC_TOKEN }}
+      s3_secretkey: ${{ secrets.S3_SECRETKEY }}
     with:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
-      redirect_from_url: ${{ needs.init.outputs.redirect_from_url }}
+      redirect_from_url: ${{ needs.vars.outputs.redirect_from_url }}
+      vite_user_pools_web_client_id: ${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
   smoke:
     name: Smoke Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -57,6 +57,7 @@ jobs:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
+      pr_number: ${{ github.event.number }}
 
   results:
     name: PR Results

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -34,16 +34,16 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     outputs:
-      redirect_from_url: ${{ steps.url.outputs.redirect_from_url }}
+      redirect_url: ${{ steps.url.outputs.redirect_url }}
     steps:
-      - name: Calculate redirect_from_url
+      - name: Calculate redirect_url
         id: url
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
           REPO="${{ github.event.repository.name }}"
           ZONE="$(( ${{ github.event.number }} % 50 ))"
           # Redirect from URL (without -frontend) - will redirect to main
-          echo "redirect_from_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+          echo "redirect_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
@@ -56,7 +56,7 @@ jobs:
     with:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
-      redirect_from_url: ${{ needs.vars.outputs.redirect_from_url }}
+      redirect_url: ${{ needs.vars.outputs.redirect_url }}
 
   smoke:
     name: Smoke Tests

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -48,7 +48,7 @@ parameters:
     value: "ca-central-1_t2HSZBHur"
   - name: VITE_ZONE
     value: PROD
-  - name: REDIRECT_FROM_URL
+  - name: REDIRECT_URL
     description: Hostname for the redirect-from URL (without protocol, e.g., nr-results-exam-12.apps.silver.devops.gov.bc.ca)
     required: true
   - name: RANDOM_EXPRESSION
@@ -103,7 +103,7 @@ objects:
                 - name: URL
                   value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
                 - name: REDIRECT_FROM_HOST
-                  value: "${REDIRECT_FROM_URL}"
+                  value: "${REDIRECT_URL}"
               ports:
                 - containerPort: 3000
                   protocol: TCP
@@ -173,7 +173,7 @@ objects:
         app: ${NAME}-${ZONE}
         purpose: url-redirect
     spec:
-      host: "${REDIRECT_FROM_URL}"
+      host: "${REDIRECT_URL}"
       port:
         targetPort: 3000-tcp
       to:

--- a/integration-tests/src/smoke.js
+++ b/integration-tests/src/smoke.js
@@ -71,8 +71,8 @@ const checks = [
 
       const dependencies = data.dependencies ?? {};
       const failingDependencies = Object.entries(dependencies)
-        .filter(([ , dependency ]) => dependency?.status === "error")
-        .map(([ name ]) => name);
+        .filter(([, dependency]) => dependency?.status === "error")
+        .map(([name]) => name);
 
       if (failingDependencies.length > 0) {
         throw new Error(
@@ -96,7 +96,7 @@ const checks = [
       if (response.status !== 200) {
         return false;
       }
-      const contentType = response.headers[ "content-type" ] ?? "";
+      const contentType = response.headers["content-type"] ?? "";
       if (!contentType.includes("text/html")) {
         throw new Error("Frontend response is not HTML content");
       }
@@ -115,23 +115,23 @@ const checks = [
     url: frontendUrl,
     validate: (response) => {
       const headers = response.headers;
-      const permissionsPolicy = headers[ 'permissions-policy' ];
+      const permissionsPolicy = headers['permissions-policy'];
       if (!permissionsPolicy) {
         throw new Error('Permissions-Policy header is missing');
       }
       // Verify that key security features are disabled
-      const requiredPolicies = [ 'camera=()', 'microphone=()', 'geolocation=()' ];
+      const requiredPolicies = ['camera=()', 'microphone=()', 'geolocation=()'];
       const hasAllPolicies = requiredPolicies.every(policy =>
         permissionsPolicy.includes(policy)
       );
       if (!hasAllPolicies) {
         throw new Error(`Permissions-Policy header missing required policies. Got: ${permissionsPolicy}`);
       }
-      const contentSecurityPolicy = headers[ 'content-security-policy' ];
+      const contentSecurityPolicy = headers['content-security-policy'];
       if (!contentSecurityPolicy) {
         throw new Error('Content-Security-Policy header is missing');
       }
-      const requiredDirectives = [ "default-src 'self'", "connect-src 'self'" ];
+      const requiredDirectives = ["default-src 'self'", "connect-src 'self'"];
       const hasDirectives = requiredDirectives.every((directive) =>
         contentSecurityPolicy.includes(directive)
       );
@@ -157,7 +157,7 @@ const checks = [
       ];
 
       for (const { name, validator, message } of requiredHeaderChecks) {
-        const headerValue = headers[ name ];
+        const headerValue = headers[name];
         if (!validator(headerValue)) {
           throw new Error(message);
         }
@@ -166,12 +166,12 @@ const checks = [
     }
   },
   // Only add redirect check if REDIRECT_URL is configured
-  ...(redirectFromUrl ? [ {
+  ...(redirectFromUrl ? [{
     name: "redirect from URL",
     url: redirectFromUrl,
     checkRedirect: true,
     expectedRedirect: frontendUrl
-  } ] : [])
+  }] : [])
 ];
 
 const validateRedirectLocation = (location, expectedRedirect) => {

--- a/integration-tests/src/smoke.js
+++ b/integration-tests/src/smoke.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const frontendUrl = process.env.FRONTEND_URL?.replace(/\/$/, "") ?? "http://localhost:3000";
-const redirectFromUrl = process.env.REDIRECT_FROM_URL?.replace(/\/$/, "");
+const redirectFromUrl = process.env.REDIRECT_URL?.replace(/\/$/, "");
 const origin = process.env.SMOKE_ORIGIN ?? frontendUrl;
 const DEFAULT_TIMEOUT_MS = 5000;
 const MIN_TIMEOUT_MS = 1000;
@@ -71,8 +71,8 @@ const checks = [
 
       const dependencies = data.dependencies ?? {};
       const failingDependencies = Object.entries(dependencies)
-        .filter(([, dependency]) => dependency?.status === "error")
-        .map(([name]) => name);
+        .filter(([ , dependency ]) => dependency?.status === "error")
+        .map(([ name ]) => name);
 
       if (failingDependencies.length > 0) {
         throw new Error(
@@ -96,7 +96,7 @@ const checks = [
       if (response.status !== 200) {
         return false;
       }
-      const contentType = response.headers["content-type"] ?? "";
+      const contentType = response.headers[ "content-type" ] ?? "";
       if (!contentType.includes("text/html")) {
         throw new Error("Frontend response is not HTML content");
       }
@@ -115,23 +115,23 @@ const checks = [
     url: frontendUrl,
     validate: (response) => {
       const headers = response.headers;
-      const permissionsPolicy = headers['permissions-policy'];
+      const permissionsPolicy = headers[ 'permissions-policy' ];
       if (!permissionsPolicy) {
         throw new Error('Permissions-Policy header is missing');
       }
       // Verify that key security features are disabled
-      const requiredPolicies = ['camera=()', 'microphone=()', 'geolocation=()'];
-      const hasAllPolicies = requiredPolicies.every(policy => 
+      const requiredPolicies = [ 'camera=()', 'microphone=()', 'geolocation=()' ];
+      const hasAllPolicies = requiredPolicies.every(policy =>
         permissionsPolicy.includes(policy)
       );
       if (!hasAllPolicies) {
         throw new Error(`Permissions-Policy header missing required policies. Got: ${permissionsPolicy}`);
       }
-      const contentSecurityPolicy = headers['content-security-policy'];
+      const contentSecurityPolicy = headers[ 'content-security-policy' ];
       if (!contentSecurityPolicy) {
         throw new Error('Content-Security-Policy header is missing');
       }
-      const requiredDirectives = ["default-src 'self'", "connect-src 'self'"];
+      const requiredDirectives = [ "default-src 'self'", "connect-src 'self'" ];
       const hasDirectives = requiredDirectives.every((directive) =>
         contentSecurityPolicy.includes(directive)
       );
@@ -157,7 +157,7 @@ const checks = [
       ];
 
       for (const { name, validator, message } of requiredHeaderChecks) {
-        const headerValue = headers[name];
+        const headerValue = headers[ name ];
         if (!validator(headerValue)) {
           throw new Error(message);
         }
@@ -165,28 +165,28 @@ const checks = [
       return response.status === 200;
     }
   },
-  // Only add redirect check if REDIRECT_FROM_URL is configured
-  ...(redirectFromUrl ? [{
+  // Only add redirect check if REDIRECT_URL is configured
+  ...(redirectFromUrl ? [ {
     name: "redirect from URL",
     url: redirectFromUrl,
     checkRedirect: true,
     expectedRedirect: frontendUrl
-  }] : [])
+  } ] : [])
 ];
 
 const validateRedirectLocation = (location, expectedRedirect) => {
   if (!location) {
     throw new Error("Redirect response missing Location header");
   }
-  
-  const expectedLocation = expectedRedirect.endsWith('/') 
-    ? expectedRedirect 
+
+  const expectedLocation = expectedRedirect.endsWith('/')
+    ? expectedRedirect
     : `${expectedRedirect}/`;
-  
+
   if (location !== expectedLocation && location !== expectedRedirect) {
     throw new Error(`Redirect location mismatch: expected ${expectedLocation} or ${expectedRedirect}, got ${location}`);
   }
-  
+
   return location;
 };
 
@@ -203,18 +203,18 @@ const executeCheck = async (check) => {
             Origin: origin
           }
         });
-        
+
         if (response.status !== 301 && response.status !== 308) {
           throw new Error(`Expected 301 or 308 redirect, got ${response.status}`);
         }
-        
+
         // Extract location and status from response
         const location = response.headers.location;
         const status = response.status;
-        
+
         // Validate redirect location
         validateRedirectLocation(location, check.expectedRedirect);
-        
+
         const attemptInfo = attempt > 1 ? ` (attempt ${attempt}/${MAX_RETRIES})` : "";
         console.info(
           `✅ ${check.name} redirected ${status} from ${check.url} to ${location}${attemptInfo}`
@@ -262,7 +262,7 @@ const executeCheck = async (check) => {
     }
     return;
   }
-  
+
   // Standard check execution
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
     try {


### PR DESCRIPTION
## Description

This PR consolidates duplicate init jobs and smoke tests into `.deploy.yml` and fixes the secret handling issues that caused the previous PR (#491) to fail.

## Changes

### `.deploy.yml` - Consolidated Reusable Workflow
- **Added `secrets` section** with `ches_client_secret`, `oc_token`, and `s3_secretkey` (all lowercase for consistency)
- **Enhanced `init` job** to deploy `common/openshift.init.yml` before calculating MOD_ZONE
- **Added `smoke` job** that always runs after deploys with auto-calculated or provided frontend URLs
- **Added inputs**: `pr_number` (optional, for detecting PR vs non-PR deployments), `frontend_url` (optional, auto-calculated for PRs)
- **Removed unnecessary input**: `vite_user_pools_web_client_id` (now accessed directly from `vars.VITE_USER_POOLS_WEB_CLIENT_ID`)
- **Removed `report_issue` input**: Issues are now automatically created for non-PR deployments (test/prod)
- Updated all secret references to use lowercase names
- Added `environment` context to init and smoke jobs for proper test/prod deployments
- Updated `report-failures` to automatically create issues for non-PR deployment failures

### `pr-open.yml` - Simplified PR Workflow
- Removed standalone `init` job (consolidated into `.deploy.yml`)
- Removed standalone `smoke` job (consolidated into `.deploy.yml`)
- Added `vars` job to calculate `redirect_url`
- Updated `deploys` job to explicitly pass secrets with correct naming
- Added `pr_number` input to prevent issue creation for PRs
- Updated `results` job dependencies (smoke tests now part of deploys)

### `merge.yml` - Simplified Merge Workflow
- Removed `init-test` and `init-prod` jobs (consolidated into `.deploy.yml`)
- Removed `smoke-test` and `smoke-prod` jobs (consolidated into `.deploy.yml`)
- Updated both deploy jobs to explicitly pass secrets with correct naming
- Added `frontend_url` inputs to both deploy jobs for explicit URL configuration
- Updated job dependencies to reflect smoke tests now being part of deploys

### `integration-tests/src/smoke.js` - Code Style
- Fixed spacing inconsistencies in array destructuring, bracket notation, and array literals
- Aligned with common JavaScript style conventions

## Key Fixes

✅ Secret names are lowercase in both declaration and usage (fixes empty/missing secrets issue)
✅ All required secrets are properly declared in reusable workflow
✅ Secrets are explicitly passed from calling workflows (not using `secrets: inherit`)
✅ Init and smoke jobs run in correct environment context for test/prod deployments
✅ Variables accessed directly from `vars` instead of being passed as inputs (consistent with `OC_NAMESPACE`, `OC_SERVER`)
✅ Automatic issue creation for non-PR deployment failures (test/prod only)
✅ Smoke tests always run (removed conditional parameter)

## Benefits

- **Eliminated duplication**: 3 init jobs → 1 reusable job, 3 smoke test jobs → 1 reusable job
- **Consistent pattern**: Follows the same consolidation approach throughout
- **Auto-calculates URLs**: PRs don't need to pass `frontend_url` (uses MOD_ZONE)
- **Automatic failure reporting**: Issues created automatically for test/prod failures
- **Cleaner workflows**: Calling workflows are simpler and easier to maintain
- **Code consistency**: Fixed spacing style issues in smoke tests

## Related

Fixes #490

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-42-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-42.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-42-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)