### PR TITLE
fix: handle direct pushes to main when PR number is unavailable

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -25,6 +25,7 @@ jobs:
       pull-requests: read
     steps:
       # Get PR number for squash merges to main
+      # Action extracts PR number from commit message (e.g., "message (#492)")
       - name: PR Number
         id: pr
         uses: bcgov/action-get-pr@v0.0.1

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -17,14 +17,25 @@ jobs:
   vars:
     name: Variables
     outputs:
-      pr: ${{ steps.pr.outputs.pr }}
+      pr: ${{ steps.tag.outputs.tag }}
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     steps:
-      # Get PR number for squash merges to main
+      # Get PR number for squash merges to main, or use commit SHA as fallback
       - name: PR Number
         id: pr
+        continue-on-error: true
         uses: bcgov/action-get-pr@v0.0.1
+      
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ -n "${{ steps.pr.outputs.pr }}" ]; then
+            echo "tag=${{ steps.pr.outputs.pr }}" >> $GITHUB_OUTPUT
+          else
+            # Use short commit SHA for direct pushes
+            echo "tag=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+          fi
 
   deploys-test:
     name: Deploys (TEST)

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,6 +20,9 @@ jobs:
       pr: ${{ steps.pr.outputs.pr }}
     runs-on: ubuntu-24.04
     timeout-minutes: 1
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       # Get PR number for squash merges to main
       - name: PR Number

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -17,25 +17,14 @@ jobs:
   vars:
     name: Variables
     outputs:
-      pr: ${{ steps.tag.outputs.tag }}
+      pr: ${{ steps.pr.outputs.pr }}
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     steps:
-      # Get PR number for squash merges to main, or use commit SHA as fallback
+      # Get PR number for squash merges to main
       - name: PR Number
         id: pr
-        continue-on-error: true
         uses: bcgov/action-get-pr@v0.0.1
-      
-      - name: Determine tag
-        id: tag
-        run: |
-          if [ -n "${{ steps.pr.outputs.pr }}" ]; then
-            echo "tag=${{ steps.pr.outputs.pr }}" >> $GITHUB_OUTPUT
-          else
-            # Use short commit SHA for direct pushes
-            echo "tag=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
-          fi
 
   deploys-test:
     name: Deploys (TEST)


### PR DESCRIPTION
## Description

Fixes workflow failure when `action-get-pr` cannot extract PR number from squash merge commit messages.

## Problem

The merge workflow was failing with:
```
Event type: push
PR number format incorrect: null
```

This happens when `action-get-pr` cannot read the commit message or query the GitHub API to extract the PR number from squash merge commits (format: "message (#PR_NUMBER)").

## Root Cause

GitHub Actions now requires explicit permissions for actions to:
- Read repository contents (commit messages)
- Query the GitHub API for PR information

The `action-get-pr` action performs checkout internally and needs these permissions to function correctly.

## Solution

Added explicit permissions to the `vars` job:
- `contents: read` - Required to read commit messages
- `pull-requests: read` - Required to query PR information from GitHub API

## Changes

- `.github/workflows/merge.yml`: Added permissions section to vars job

## Testing

This should now work correctly for squash merges to main, extracting the PR number from commit messages like:
- "chore: consolidate duplicate init and smoke test jobs into .deploy.yml (#492)"

The workflow will still fail (as intended) if there's no PR number in the commit message, since all changes to main must go through PRs.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-43-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-43.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-43-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)