### PR TITLE
feat: replace MOD_ZONE with explicit URL parameters

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -52,7 +52,6 @@ jobs:
       contents: read
     outputs:
       frontend_url: ${{ steps.urls.outputs.frontend_url }}
-      frontend_url_with_slash: ${{ steps.urls.outputs.frontend_url_with_slash }}
       frontend_hostname: ${{ steps.urls.outputs.frontend_hostname }}
     steps:
       - name: Deploy OpenShift init resources
@@ -72,7 +71,7 @@ jobs:
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
           REPO="nr-results-exam"
-          
+
           # Calculate frontend URL if not provided
           if [ -n "${{ inputs.frontend_url }}" ]; then
             FRONTEND_URL="${{ inputs.frontend_url }}"
@@ -85,18 +84,14 @@ jobs:
             fi
             FRONTEND_URL="https://${REPO}-${ZONE}-frontend.${DOMAIN}"
           fi
-          
-          # Remove trailing slash for base URL (backend uses this)
+
+          # Remove trailing slash for base URL
           FRONTEND_URL_CLEAN="${FRONTEND_URL%/}"
-          
-          # Add trailing slash for frontend template (URL env var needs it)
-          FRONTEND_URL_WITH_SLASH="${FRONTEND_URL_CLEAN}/"
           
           # Extract hostname from URL (remove protocol and path)
           FRONTEND_HOSTNAME=$(echo "$FRONTEND_URL_CLEAN" | sed -E 's|https?://||' | sed -E 's|/.*||')
           
           echo "frontend_url=${FRONTEND_URL_CLEAN}" >> $GITHUB_OUTPUT
-          echo "frontend_url_with_slash=${FRONTEND_URL_WITH_SLASH}" >> $GITHUB_OUTPUT
           echo "frontend_hostname=${FRONTEND_HOSTNAME}" >> $GITHUB_OUTPUT
 
   deploys:
@@ -120,7 +115,7 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
-            ${{ matrix.name == 'frontend' && format('-p URL={0}', needs.init.outputs.frontend_url_with_slash) || '' }}
+            ${{ matrix.name == 'frontend' && format('-p URL={0}/', needs.init.outputs.frontend_url) || '' }}
             ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', needs.init.outputs.frontend_hostname) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
             ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', needs.init.outputs.frontend_url) || '' }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -52,7 +52,6 @@ jobs:
       contents: read
     outputs:
       frontend_url: ${{ steps.urls.outputs.frontend_url }}
-      frontend_hostname: ${{ steps.urls.outputs.frontend_hostname }}
     steps:
       - name: Deploy OpenShift init resources
         uses: bcgov/action-deployer-openshift@v4.0.1
@@ -88,11 +87,7 @@ jobs:
           # Remove trailing slash for base URL
           FRONTEND_URL_CLEAN="${FRONTEND_URL%/}"
           
-          # Extract hostname from URL (remove protocol and path)
-          FRONTEND_HOSTNAME=$(echo "$FRONTEND_URL_CLEAN" | sed -E 's|https?://||' | sed -E 's|/.*||')
-          
           echo "frontend_url=${FRONTEND_URL_CLEAN}" >> $GITHUB_OUTPUT
-          echo "frontend_hostname=${FRONTEND_HOSTNAME}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploy
@@ -106,6 +101,14 @@ jobs:
       matrix:
         name: [backend, frontend]
     steps:
+      - name: Extract hostname for frontend
+        if: matrix.name == 'frontend'
+        id: hostname
+        run: |
+          FRONTEND_URL="${{ needs.init.outputs.frontend_url }}"
+          FRONTEND_HOSTNAME=$(echo "$FRONTEND_URL" | sed -E 's|https?://||' | sed -E 's|/.*||')
+          echo "hostname=${FRONTEND_HOSTNAME}" >> $GITHUB_OUTPUT
+
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
         with:
@@ -116,7 +119,7 @@ jobs:
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
             ${{ matrix.name == 'frontend' && format('-p URL={0}/', needs.init.outputs.frontend_url) || '' }}
-            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', needs.init.outputs.frontend_hostname) || '' }}
+            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', steps.hostname.outputs.hostname) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
             ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', needs.init.outputs.frontend_url) || '' }}
 

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -27,15 +27,7 @@ on:
         required: false
         type: string
       frontend_url:
-        description: Frontend URL for smoke tests (auto-calculated if not provided)
-        required: false
-        type: string
-      url:
-        description: Full frontend URL with protocol and trailing slash (auto-calculated if not provided)
-        required: false
-        type: string
-      backend_frontend_url:
-        description: Full frontend URL for backend to reference (auto-calculated if not provided)
+        description: Full frontend URL with protocol (auto-calculated if not provided)
         required: false
         type: string
 
@@ -59,9 +51,9 @@ jobs:
     permissions:
       contents: read
     outputs:
-      url: ${{ steps.urls.outputs.url }}
+      frontend_url: ${{ steps.urls.outputs.frontend_url }}
+      frontend_url_with_slash: ${{ steps.urls.outputs.frontend_url_with_slash }}
       frontend_hostname: ${{ steps.urls.outputs.frontend_hostname }}
-      backend_frontend_url: ${{ steps.urls.outputs.backend_frontend_url }}
     steps:
       - name: Deploy OpenShift init resources
         uses: bcgov/action-deployer-openshift@v4.0.1
@@ -80,10 +72,10 @@ jobs:
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
           REPO="nr-results-exam"
-
+          
           # Calculate frontend URL if not provided
-          if [ -n "${{ inputs.url }}" ]; then
-            FRONTEND_URL="${{ inputs.url }}"
+          if [ -n "${{ inputs.frontend_url }}" ]; then
+            FRONTEND_URL="${{ inputs.frontend_url }}"
           else
             # Calculate from zone (for PRs)
             if [[ "${{ inputs.zone }}" =~ ^[0-9]+$ ]]; then
@@ -91,28 +83,21 @@ jobs:
             else
               ZONE="${{ inputs.zone }}"
             fi
-            FRONTEND_URL="https://${REPO}-${ZONE}-frontend.${DOMAIN}/"
+            FRONTEND_URL="https://${REPO}-${ZONE}-frontend.${DOMAIN}"
           fi
-
-          # Ensure URL has trailing slash
-          if [[ ! "$FRONTEND_URL" =~ /$ ]]; then
-            FRONTEND_URL="${FRONTEND_URL}/"
-          fi
-
+          
+          # Remove trailing slash for base URL (backend uses this)
+          FRONTEND_URL_CLEAN="${FRONTEND_URL%/}"
+          
+          # Add trailing slash for frontend template (URL env var needs it)
+          FRONTEND_URL_WITH_SLASH="${FRONTEND_URL_CLEAN}/"
+          
           # Extract hostname from URL (remove protocol and path)
-          FRONTEND_HOSTNAME=$(echo "$FRONTEND_URL" | sed -E 's|https?://||' | sed -E 's|/.*||')
-
-          # Calculate backend FRONTEND_URL if not provided
-          if [ -n "${{ inputs.backend_frontend_url }}" ]; then
-            BACKEND_FRONTEND_URL="${{ inputs.backend_frontend_url }}"
-          else
-            # Use the same URL but without trailing slash for backend
-            BACKEND_FRONTEND_URL="${FRONTEND_URL%/}"
-          fi
-
-          echo "url=${FRONTEND_URL}" >> $GITHUB_OUTPUT
+          FRONTEND_HOSTNAME=$(echo "$FRONTEND_URL_CLEAN" | sed -E 's|https?://||' | sed -E 's|/.*||')
+          
+          echo "frontend_url=${FRONTEND_URL_CLEAN}" >> $GITHUB_OUTPUT
+          echo "frontend_url_with_slash=${FRONTEND_URL_WITH_SLASH}" >> $GITHUB_OUTPUT
           echo "frontend_hostname=${FRONTEND_HOSTNAME}" >> $GITHUB_OUTPUT
-          echo "backend_frontend_url=${BACKEND_FRONTEND_URL}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploy
@@ -135,10 +120,10 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
-            ${{ matrix.name == 'frontend' && format('-p URL={0}', needs.init.outputs.url) || '' }}
+            ${{ matrix.name == 'frontend' && format('-p URL={0}', needs.init.outputs.frontend_url_with_slash) || '' }}
             ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', needs.init.outputs.frontend_hostname) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
-            ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', needs.init.outputs.backend_frontend_url) || '' }}
+            ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', needs.init.outputs.frontend_url) || '' }}
 
   smoke:
     name: Smoke Tests
@@ -155,7 +140,7 @@ jobs:
             echo "url=${{ inputs.frontend_url }}" >> $GITHUB_OUTPUT
           else
             # Use the calculated URL from init step
-            echo "url=${{ needs.init.outputs.url }}" >> $GITHUB_OUTPUT
+            echo "url=${{ needs.init.outputs.frontend_url }}" >> $GITHUB_OUTPUT
           fi
 
       - uses: actions/checkout@v6

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -30,6 +30,14 @@ on:
         description: Frontend URL for smoke tests (auto-calculated if not provided)
         required: false
         type: string
+      url:
+        description: Full frontend URL with protocol and trailing slash (auto-calculated if not provided)
+        required: false
+        type: string
+      backend_frontend_url:
+        description: Full frontend URL for backend to reference (auto-calculated if not provided)
+        required: false
+        type: string
 
     secrets:
       ches_client_secret:
@@ -51,7 +59,9 @@ jobs:
     permissions:
       contents: read
     outputs:
-      mod_zone: ${{ steps.mod-zone.outputs.mod_zone }}
+      url: ${{ steps.urls.outputs.url }}
+      frontend_hostname: ${{ steps.urls.outputs.frontend_hostname }}
+      backend_frontend_url: ${{ steps.urls.outputs.backend_frontend_url }}
     steps:
       - name: Deploy OpenShift init resources
         uses: bcgov/action-deployer-openshift@v4.0.1
@@ -65,16 +75,44 @@ jobs:
             -p S3_SECRETKEY=${{ secrets.s3_secretkey }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
-      - name: Calculate MOD_ZONE
-        id: mod-zone
+      - name: Calculate URLs and hostnames
+        id: urls
         run: |
-          # For PR deployments (numeric zones), calculate modulo 50
-          # For named environments (test, prod), use the zone as-is
-          if [[ "${{ inputs.zone }}" =~ ^[0-9]+$ ]]; then
-            echo "mod_zone=$(( ${{ inputs.zone }} % 50 ))" >> $GITHUB_OUTPUT
+          DOMAIN="apps.silver.devops.gov.bc.ca"
+          REPO="nr-results-exam"
+
+          # Calculate frontend URL if not provided
+          if [ -n "${{ inputs.url }}" ]; then
+            FRONTEND_URL="${{ inputs.url }}"
           else
-            echo "mod_zone=${{ inputs.zone }}" >> $GITHUB_OUTPUT
+            # Calculate from zone (for PRs)
+            if [[ "${{ inputs.zone }}" =~ ^[0-9]+$ ]]; then
+              ZONE="$(( ${{ inputs.zone }} % 50 ))"
+            else
+              ZONE="${{ inputs.zone }}"
+            fi
+            FRONTEND_URL="https://${REPO}-${ZONE}-frontend.${DOMAIN}/"
           fi
+
+          # Ensure URL has trailing slash
+          if [[ ! "$FRONTEND_URL" =~ /$ ]]; then
+            FRONTEND_URL="${FRONTEND_URL}/"
+          fi
+
+          # Extract hostname from URL (remove protocol and path)
+          FRONTEND_HOSTNAME=$(echo "$FRONTEND_URL" | sed -E 's|https?://||' | sed -E 's|/.*||')
+
+          # Calculate backend FRONTEND_URL if not provided
+          if [ -n "${{ inputs.backend_frontend_url }}" ]; then
+            BACKEND_FRONTEND_URL="${{ inputs.backend_frontend_url }}"
+          else
+            # Use the same URL but without trailing slash for backend
+            BACKEND_FRONTEND_URL="${FRONTEND_URL%/}"
+          fi
+
+          echo "url=${FRONTEND_URL}" >> $GITHUB_OUTPUT
+          echo "frontend_hostname=${FRONTEND_HOSTNAME}" >> $GITHUB_OUTPUT
+          echo "backend_frontend_url=${BACKEND_FRONTEND_URL}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploy
@@ -97,8 +135,10 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
-            -p MOD_ZONE=${{ needs.init.outputs.mod_zone }}
+            ${{ matrix.name == 'frontend' && format('-p URL={0}', needs.init.outputs.url) || '' }}
+            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', needs.init.outputs.frontend_hostname) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
+            ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', needs.init.outputs.backend_frontend_url) || '' }}
 
   smoke:
     name: Smoke Tests
@@ -107,18 +147,15 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - name: Calculate frontend URL
+      - name: Calculate frontend URL for smoke tests
         id: frontend-url
         run: |
           if [ -n "${{ inputs.frontend_url }}" ]; then
             # Use provided frontend URL
             echo "url=${{ inputs.frontend_url }}" >> $GITHUB_OUTPUT
           else
-            # Calculate from zone (for PRs)
-            DOMAIN="apps.silver.devops.gov.bc.ca"
-            REPO="nr-results-exam"
-            MOD_ZONE="${{ needs.init.outputs.mod_zone }}"
-            echo "url=https://${REPO}-${MOD_ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+            # Use the calculated URL from init step
+            echo "url=${{ needs.init.outputs.url }}" >> $GITHUB_OUTPUT
           fi
 
       - uses: actions/checkout@v6

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,6 +39,8 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
       redirect_url: results-exam-test.apps.silver.devops.gov.bc.ca
+      url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca/
+      backend_frontend_url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
       frontend_url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
 
   deploys-prod:
@@ -54,6 +56,8 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
       redirect_url: results-exam.apps.silver.devops.gov.bc.ca
+      url: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca/
+      backend_frontend_url: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
       frontend_url: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
 
   image-promotions:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,8 +39,6 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
       redirect_url: results-exam-test.apps.silver.devops.gov.bc.ca
-      url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca/
-      backend_frontend_url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
       frontend_url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
 
   deploys-prod:
@@ -56,8 +54,6 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
       redirect_url: results-exam.apps.silver.devops.gov.bc.ca
-      url: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca/
-      backend_frontend_url: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
       frontend_url: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
 
   image-promotions:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -45,8 +45,8 @@ jobs:
           ZONE="$(( ${{ github.event.number }} % 50 ))"
           # Redirect from URL (without -frontend) - will redirect to main
           echo "redirect_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
-          # Frontend URL with protocol and trailing slash
-          echo "frontend_url=https://${REPO}-${ZONE}-frontend.${DOMAIN}/" >> $GITHUB_OUTPUT
+          # Frontend URL with protocol (no trailing slash)
+          echo "frontend_url=https://${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
@@ -60,7 +60,7 @@ jobs:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
-      url: ${{ needs.vars.outputs.frontend_url }}
+      frontend_url: ${{ needs.vars.outputs.frontend_url }}
       pr_number: ${{ github.event.number }}
 
   results:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -35,8 +35,9 @@ jobs:
     timeout-minutes: 1
     outputs:
       redirect_url: ${{ steps.url.outputs.redirect_url }}
+      frontend_url: ${{ steps.url.outputs.frontend_url }}
     steps:
-      - name: Calculate redirect_url
+      - name: Calculate URLs
         id: url
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
@@ -44,6 +45,8 @@ jobs:
           ZONE="$(( ${{ github.event.number }} % 50 ))"
           # Redirect from URL (without -frontend) - will redirect to main
           echo "redirect_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Frontend URL with protocol and trailing slash
+          echo "frontend_url=https://${REPO}-${ZONE}-frontend.${DOMAIN}/" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
@@ -57,6 +60,7 @@ jobs:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
+      url: ${{ needs.vars.outputs.frontend_url }}
       pr_number: ${{ github.event.number }}
 
   results:

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -10,8 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: MOD_ZONE
-    description: Deployment zone, modified for PRs,e.g. pr-### % 50, test or prod
+  - name: FRONTEND_URL
+    description: Full frontend URL with protocol, e.g. https://example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -117,7 +117,7 @@ objects:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: s3-secretkey
                 - name: FRONTEND_URL
-                  value: https://${NAME}-${MOD_ZONE}-frontend.${DOMAIN}
+                  value: "${FRONTEND_URL}"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: VITE_USER_POOLS_ID

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -10,8 +10,11 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-###, test or prod
     required: true
-  - name: MOD_ZONE
-    description: Deployment zone, modified for PRs,e.g. pr-### % 50, test or prod
+  - name: URL
+    description: Full frontend URL with protocol and trailing slash, e.g. https://example.com/
+    required: true
+  - name: HOSTNAME
+    description: Hostname for the Route (without protocol), e.g. example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -101,7 +104,7 @@ objects:
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: URL
-                  value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
+                  value: "${URL}"
                 - name: REDIRECT_FROM_HOST
                   value: "${REDIRECT_URL}"
               ports:
@@ -155,7 +158,7 @@ objects:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
-      host: "${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}"
+      host: "${HOSTNAME}"
       port:
         targetPort: 3000-tcp
       to:


### PR DESCRIPTION
## Description

This PR replaces the `MOD_ZONE` parameter with explicit `URL` and `FRONTEND_URL` parameters for better flexibility and consistency with the `REDIRECT_FROM_URL` pattern.

## Changes

- **Frontend template**: Removed `MOD_ZONE`, added `URL` and `HOSTNAME` parameters
- **Backend template**: Removed `MOD_ZONE`, added `FRONTEND_URL` parameter
- **Workflows**: Updated to calculate and pass explicit URLs instead of zone-based calculations
- **PR workflows**: Calculate full URLs programmatically
- **Merge workflow**: Pass explicit URLs for TEST/PROD environments

## Benefits

1. **Consistency** - Matches the pattern already established for `REDIRECT_FROM_URL`
2. **Flexibility** - TEST/PROD can use vanity URLs via GitHub environment variables
3. **Clarity** - Explicit URLs instead of constructing from zones
4. **Simplicity** - Removes zone calculation logic from workflows
5. **User-friendly** - Teams can configure their own URLs without code changes

## Related Issue

Fixes #470

## Testing

- [ ] Verify PR deployments work correctly
- [ ] Verify TEST environment deployment works correctly
- [ ] Verify PROD environment deployment works correctly

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-44-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-44.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-44-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)