### PR TITLE
feat: replace MOD_ZONE with explicit URL parameters

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -52,7 +52,6 @@ jobs:
       contents: read
     outputs:
       frontend_url: ${{ inputs.frontend_url }}
-      frontend_hostname: ${{ steps.hostname.outputs.hostname }}
     steps:
       - name: Deploy OpenShift init resources
         uses: bcgov/action-deployer-openshift@v4.0.1
@@ -66,14 +65,6 @@ jobs:
             -p S3_SECRETKEY=${{ secrets.s3_secretkey }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
-      - name: Extract hostname from frontend URL
-        id: hostname
-        run: |
-          FRONTEND_URL="${{ inputs.frontend_url }}"
-          # Remove protocol and path to get hostname
-          HOSTNAME=$(echo "$FRONTEND_URL" | sed -E 's|https?://||' | sed -E 's|/.*||')
-          echo "hostname=${HOSTNAME}" >> $GITHUB_OUTPUT
-
   deploys:
     name: Deploy
     needs: [init]
@@ -86,6 +77,15 @@ jobs:
       matrix:
         name: [backend, frontend]
     steps:
+      - name: Extract hostname for frontend
+        if: matrix.name == 'frontend'
+        id: hostname
+        run: |
+          FRONTEND_URL="${{ needs.init.outputs.frontend_url }}"
+          # Remove protocol and path to get hostname
+          HOSTNAME=$(echo "$FRONTEND_URL" | sed -E 's|https?://||' | sed -E 's|/.*||')
+          echo "hostname=${HOSTNAME}" >> $GITHUB_OUTPUT
+
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
         with:
@@ -96,7 +96,7 @@ jobs:
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
             ${{ matrix.name == 'frontend' && format('-p URL={0}/', needs.init.outputs.frontend_url) || '' }}
-            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', needs.init.outputs.frontend_hostname) || '' }}
+            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', steps.hostname.outputs.hostname) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
             ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', needs.init.outputs.frontend_url) || '' }}
 

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -95,7 +95,6 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
-            ${{ matrix.name == 'frontend' && format('-p URL={0}/', needs.init.outputs.frontend_url) || '' }}
             ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', steps.hostname.outputs.hostname) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
             ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', needs.init.outputs.frontend_url) || '' }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -27,8 +27,8 @@ on:
         required: false
         type: string
       frontend_url:
-        description: Frontend URL for smoke tests (auto-calculated if not provided)
-        required: false
+        description: Full frontend URL (required)
+        required: true
         type: string
 
     secrets:
@@ -51,7 +51,8 @@ jobs:
     permissions:
       contents: read
     outputs:
-      mod_zone: ${{ steps.mod-zone.outputs.mod_zone }}
+      frontend_url: ${{ inputs.frontend_url }}
+      frontend_hostname: ${{ steps.hostname.outputs.hostname }}
     steps:
       - name: Deploy OpenShift init resources
         uses: bcgov/action-deployer-openshift@v4.0.1
@@ -65,16 +66,13 @@ jobs:
             -p S3_SECRETKEY=${{ secrets.s3_secretkey }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
-      - name: Calculate MOD_ZONE
-        id: mod-zone
+      - name: Extract hostname from frontend URL
+        id: hostname
         run: |
-          # For PR deployments (numeric zones), calculate modulo 50
-          # For named environments (test, prod), use the zone as-is
-          if [[ "${{ inputs.zone }}" =~ ^[0-9]+$ ]]; then
-            echo "mod_zone=$(( ${{ inputs.zone }} % 50 ))" >> $GITHUB_OUTPUT
-          else
-            echo "mod_zone=${{ inputs.zone }}" >> $GITHUB_OUTPUT
-          fi
+          FRONTEND_URL="${{ inputs.frontend_url }}"
+          # Remove protocol and path to get hostname
+          HOSTNAME=$(echo "$FRONTEND_URL" | sed -E 's|https?://||' | sed -E 's|/.*||')
+          echo "hostname=${HOSTNAME}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploy
@@ -97,8 +95,10 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
-            -p MOD_ZONE=${{ needs.init.outputs.mod_zone }}
+            ${{ matrix.name == 'frontend' && format('-p URL={0}/', needs.init.outputs.frontend_url) || '' }}
+            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', needs.init.outputs.frontend_hostname) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
+            ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', needs.init.outputs.frontend_url) || '' }}
 
   smoke:
     name: Smoke Tests
@@ -107,19 +107,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - name: Calculate frontend URL
+      - name: Get frontend URL for smoke tests
         id: frontend-url
         run: |
-          if [ -n "${{ inputs.frontend_url }}" ]; then
-            # Use provided frontend URL
-            echo "url=${{ inputs.frontend_url }}" >> $GITHUB_OUTPUT
-          else
-            # Calculate from zone (for PRs)
-            DOMAIN="apps.silver.devops.gov.bc.ca"
-            REPO="nr-results-exam"
-            MOD_ZONE="${{ needs.init.outputs.mod_zone }}"
-            echo "url=https://${REPO}-${MOD_ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
-          fi
+          echo "url=${{ needs.init.outputs.frontend_url }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -35,8 +35,9 @@ jobs:
     timeout-minutes: 1
     outputs:
       redirect_url: ${{ steps.url.outputs.redirect_url }}
+      frontend_url: ${{ steps.url.outputs.frontend_url }}
     steps:
-      - name: Calculate redirect_url
+      - name: Calculate URLs
         id: url
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
@@ -44,6 +45,8 @@ jobs:
           ZONE="$(( ${{ github.event.number }} % 50 ))"
           # Redirect from URL (without -frontend) - will redirect to main
           echo "redirect_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Frontend URL (ZONE is already modulo 50)
+          echo "frontend_url=https://${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
@@ -57,6 +60,7 @@ jobs:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
+      frontend_url: ${{ needs.vars.outputs.frontend_url }}
       pr_number: ${{ github.event.number }}
 
   results:

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -10,8 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: MOD_ZONE
-    description: Deployment zone, modified for PRs,e.g. pr-### % 50, test or prod
+  - name: FRONTEND_URL
+    description: Full frontend URL with protocol, e.g. https://example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -117,7 +117,7 @@ objects:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: s3-secretkey
                 - name: FRONTEND_URL
-                  value: https://${NAME}-${MOD_ZONE}-frontend.${DOMAIN}
+                  value: "${FRONTEND_URL}"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: VITE_USER_POOLS_ID

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -10,8 +10,11 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-###, test or prod
     required: true
-  - name: MOD_ZONE
-    description: Deployment zone, modified for PRs,e.g. pr-### % 50, test or prod
+  - name: URL
+    description: Full frontend URL with protocol and trailing slash, e.g. https://example.com/
+    required: true
+  - name: HOSTNAME
+    description: Hostname for the Route (without protocol), e.g. example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -101,7 +104,7 @@ objects:
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: URL
-                  value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
+                  value: "${URL}"
                 - name: REDIRECT_FROM_HOST
                   value: "${REDIRECT_URL}"
               ports:
@@ -155,7 +158,7 @@ objects:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
-      host: "${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}"
+      host: "${HOSTNAME}"
       port:
         targetPort: 3000-tcp
       to:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -14,7 +14,7 @@ parameters:
     description: Full frontend URL with protocol and trailing slash, e.g. https://example.com/
     required: true
   - name: HOSTNAME
-    description: Hostname for the Route (without protocol), e.g. example.com
+    description: Hostname extracted from URL for the Route (automatically derived from URL in workflow)
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -10,11 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-###, test or prod
     required: true
-  - name: URL
-    description: Full frontend URL with protocol and trailing slash, e.g. https://example.com/
-    required: true
   - name: HOSTNAME
-    description: Hostname extracted from URL for the Route (automatically derived from URL in workflow)
+    description: Hostname for the Route and URL construction, e.g. example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -104,7 +101,7 @@ objects:
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: URL
-                  value: "${URL}"
+                  value: "https://${HOSTNAME}/"
                 - name: REDIRECT_FROM_HOST
                   value: "${REDIRECT_URL}"
               ports:


### PR DESCRIPTION
## Description

This PR replaces the `MOD_ZONE` parameter with explicit URL parameters. URLs are calculated in `pr-open.yml` and passed as static values in `merge.yml`.

## Changes

- **pr-open.yml**: Calculate frontend URL with MOD_ZONE logic (PR % 50) and pass it directly
- **merge.yml**: Already passes static URLs, no changes needed
- **.deploy.yml**: Remove MOD_ZONE calculation, accept `frontend_url` as required parameter
- **Frontend template**: Remove `MOD_ZONE`, add `URL` and `HOSTNAME` parameters
- **Backend template**: Remove `MOD_ZONE`, add `FRONTEND_URL` parameter

## Benefits

1. **Simplicity** - URLs calculated once in pr-open.yml, static in merge.yml
2. **No zone calculations in shared workflow** - Removed from .deploy.yml
3. **Flexibility** - TEST/PROD can use vanity URLs via GitHub environment variables
4. **Consistency** - Matches the `REDIRECT_FROM_URL` pattern
5. **User-friendly** - Teams can configure their own URLs without code changes

## Related Issue

Fixes #470

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-45-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-45.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-45-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)