### PR TITLE
feat: replace MOD_ZONE with hostname param

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -27,8 +27,8 @@ on:
         required: false
         type: string
       frontend_url:
-        description: Frontend URL for smoke tests (auto-calculated if not provided)
-        required: false
+        description: Full frontend URL
+        required: true
         type: string
 
     secrets:
@@ -44,14 +44,12 @@ on:
 
 jobs:
   init:
-    name: Init and calculate deployment parameters
+    name: Init
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     permissions:
       contents: read
-    outputs:
-      mod_zone: ${{ steps.mod-zone.outputs.mod_zone }}
     steps:
       - name: Deploy OpenShift init resources
         uses: bcgov/action-deployer-openshift@v4.0.1
@@ -65,17 +63,6 @@ jobs:
             -p S3_SECRETKEY=${{ secrets.s3_secretkey }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
 
-      - name: Calculate MOD_ZONE
-        id: mod-zone
-        run: |
-          # For PR deployments (numeric zones), calculate modulo 50
-          # For named environments (test, prod), use the zone as-is
-          if [[ "${{ inputs.zone }}" =~ ^[0-9]+$ ]]; then
-            echo "mod_zone=$(( ${{ inputs.zone }} % 50 ))" >> $GITHUB_OUTPUT
-          else
-            echo "mod_zone=${{ inputs.zone }}" >> $GITHUB_OUTPUT
-          fi
-
   deploys:
     name: Deploy
     needs: [init]
@@ -88,6 +75,12 @@ jobs:
       matrix:
         name: [backend, frontend]
     steps:
+      - name: Extract hostname for frontend
+        if: matrix.name == 'frontend'
+        id: hostname
+        run: |
+          echo "hostname=$(echo '${{ inputs.frontend_url }}' | sed -E 's|https?://||' | sed -E 's|/.*||')" >> $GITHUB_OUTPUT
+
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
         with:
@@ -97,8 +90,9 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
-            -p MOD_ZONE=${{ needs.init.outputs.mod_zone }}
+            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', steps.hostname.outputs.hostname) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
+            ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', inputs.frontend_url) || '' }}
 
   smoke:
     name: Smoke Tests
@@ -107,19 +101,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - name: Calculate frontend URL
+      - name: Set frontend URL for smoke tests
         id: frontend-url
         run: |
-          if [ -n "${{ inputs.frontend_url }}" ]; then
-            # Use provided frontend URL
-            echo "url=${{ inputs.frontend_url }}" >> $GITHUB_OUTPUT
-          else
-            # Calculate from zone (for PRs)
-            DOMAIN="apps.silver.devops.gov.bc.ca"
-            REPO="nr-results-exam"
-            MOD_ZONE="${{ needs.init.outputs.mod_zone }}"
-            echo "url=https://${REPO}-${MOD_ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
-          fi
+          echo "url=${{ inputs.frontend_url }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -26,8 +26,8 @@ on:
         description: PR number if this is a PR deployment (empty for non-PRs)
         required: false
         type: string
-      frontend_url:
-        description: Full frontend URL
+      frontend_hostname:
+        description: Frontend hostname (without protocol)
         required: true
         type: string
 
@@ -75,12 +75,6 @@ jobs:
       matrix:
         name: [backend, frontend]
     steps:
-      - name: Extract hostname for frontend
-        if: matrix.name == 'frontend'
-        id: hostname
-        run: |
-          echo "hostname=$(echo '${{ inputs.frontend_url }}' | sed -E 's|https?://||' | sed -E 's|/.*||')" >> $GITHUB_OUTPUT
-
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
         with:
@@ -90,9 +84,9 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
-            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', steps.hostname.outputs.hostname) || '' }}
+            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', inputs.frontend_hostname) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
-            ${{ matrix.name == 'backend' && format('-p FRONTEND_URL={0}', inputs.frontend_url) || '' }}
+            ${{ matrix.name == 'backend' && format('-p FRONTEND_HOSTNAME={0}', inputs.frontend_hostname) || '' }}
 
   smoke:
     name: Smoke Tests
@@ -104,7 +98,7 @@ jobs:
       - name: Set frontend URL for smoke tests
         id: frontend-url
         run: |
-          echo "url=${{ inputs.frontend_url }}" >> $GITHUB_OUTPUT
+          echo "url=https://${{ inputs.frontend_hostname }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -77,7 +77,7 @@ jobs:
           - name: backend
             params: -p FRONTEND_HOSTNAME=${{ inputs.frontend_hostname }}
           - name: frontend
-            params: -p HOSTNAME=${{ inputs.frontend_hostname }} -p REDIRECT_URL=${{ inputs.redirect_url }}
+            params: -p FRONTEND_HOSTNAME=${{ inputs.frontend_hostname }} -p REDIRECT_URL=${{ inputs.redirect_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -73,11 +73,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        include:
-          - name: backend
-            params: -p HOSTNAME=${{ inputs.hostname }}
-          - name: frontend
-            params: -p HOSTNAME=${{ inputs.hostname }} -p REDIRECT_URL=${{ inputs.redirect_url }}
+        name: [frontend, backend]
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
@@ -86,9 +82,11 @@ jobs:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.oc_token }}
-          parameters: -p ZONE=${{ inputs.zone }}
+          parameters: |
+            -p HOSTNAME=${{ inputs.hostname }}
             -p TAG=${{ inputs.tag }}
-            ${{ matrix.params }}
+            -p ZONE=${{ inputs.zone }}
+            ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
 
   smoke:
     name: Smoke Tests

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -73,7 +73,11 @@ jobs:
       contents: read
     strategy:
       matrix:
-        name: [backend, frontend]
+        include:
+          - name: backend
+            params: -p FRONTEND_HOSTNAME=${{ inputs.frontend_hostname }}
+          - name: frontend
+            params: -p HOSTNAME=${{ inputs.frontend_hostname }} -p REDIRECT_URL=${{ inputs.redirect_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
@@ -84,9 +88,7 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
-            ${{ matrix.name == 'frontend' && format('-p HOSTNAME={0}', inputs.frontend_hostname) || '' }}
-            ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
-            ${{ matrix.name == 'backend' && format('-p FRONTEND_HOSTNAME={0}', inputs.frontend_hostname) || '' }}
+            ${{ matrix.params }}
 
   smoke:
     name: Smoke Tests

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -75,9 +75,9 @@ jobs:
       matrix:
         include:
           - name: backend
-            params: -p FRONTEND_HOSTNAME=${{ inputs.frontend_hostname }}
+            params: -p HOSTNAME=${{ inputs.frontend_hostname }}
           - name: frontend
-            params: -p FRONTEND_HOSTNAME=${{ inputs.frontend_hostname }} -p REDIRECT_URL=${{ inputs.redirect_url }}
+            params: -p HOSTNAME=${{ inputs.frontend_hostname }} -p REDIRECT_URL=${{ inputs.redirect_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -26,8 +26,8 @@ on:
         description: PR number if this is a PR deployment (empty for non-PRs)
         required: false
         type: string
-      frontend_hostname:
-        description: Frontend hostname (without protocol)
+      hostname:
+        description: Hostname (without protocol)
         required: true
         type: string
 
@@ -75,9 +75,9 @@ jobs:
       matrix:
         include:
           - name: backend
-            params: -p HOSTNAME=${{ inputs.frontend_hostname }}
+            params: -p HOSTNAME=${{ inputs.hostname }}
           - name: frontend
-            params: -p HOSTNAME=${{ inputs.frontend_hostname }} -p REDIRECT_URL=${{ inputs.redirect_url }}
+            params: -p HOSTNAME=${{ inputs.hostname }} -p REDIRECT_URL=${{ inputs.redirect_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
@@ -100,7 +100,7 @@ jobs:
       - name: Set frontend URL for smoke tests
         id: frontend-url
         run: |
-          echo "url=https://${{ inputs.frontend_hostname }}" >> $GITHUB_OUTPUT
+          echo "url=https://${{ inputs.hostname }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,7 +39,7 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
       redirect_url: results-exam-test.apps.silver.devops.gov.bc.ca
-      frontend_url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
+      frontend_hostname: nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
 
   deploys-prod:
     name: Deploys (PROD)
@@ -54,7 +54,7 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
       redirect_url: results-exam.apps.silver.devops.gov.bc.ca
-      frontend_url: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
+      frontend_hostname: nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
 
   image-promotions:
     name: Promote images

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,7 +39,7 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
       redirect_url: results-exam-test.apps.silver.devops.gov.bc.ca
-      frontend_hostname: nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
+      hostname: nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
 
   deploys-prod:
     name: Deploys (PROD)
@@ -54,7 +54,7 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
       redirect_url: results-exam.apps.silver.devops.gov.bc.ca
-      frontend_hostname: nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
+      hostname: nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
 
   image-promotions:
     name: Promote images

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -44,7 +44,7 @@ jobs:
           REPO="${{ github.event.repository.name }}"
           ZONE="$(( ${{ github.event.number }} % 50 ))"
           echo "redirect_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
-          echo "frontend_url=https://${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          echo "frontend_hostname=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
@@ -58,7 +58,7 @@ jobs:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
-      frontend_url: ${{ needs.vars.outputs.frontend_url }}
+      frontend_hostname: ${{ needs.vars.outputs.frontend_hostname }}
       pr_number: ${{ github.event.number }}
 
   results:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 1
     outputs:
       redirect_url: ${{ steps.url.outputs.redirect_url }}
-      frontend_url: ${{ steps.url.outputs.frontend_url }}
+      hostname: ${{ steps.url.outputs.hostname }}
     steps:
       - name: Calculate URLs
         id: url
@@ -44,7 +44,7 @@ jobs:
           REPO="${{ github.event.repository.name }}"
           ZONE="$(( ${{ github.event.number }} % 50 ))"
           echo "redirect_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
-          echo "frontend_hostname=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          echo "hostname=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
@@ -58,7 +58,7 @@ jobs:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
-      frontend_hostname: ${{ needs.vars.outputs.frontend_hostname }}
+      hostname: ${{ needs.vars.outputs.hostname }}
       pr_number: ${{ github.event.number }}
 
   results:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -35,15 +35,16 @@ jobs:
     timeout-minutes: 1
     outputs:
       redirect_url: ${{ steps.url.outputs.redirect_url }}
+      frontend_url: ${{ steps.url.outputs.frontend_url }}
     steps:
-      - name: Calculate redirect_url
+      - name: Calculate URLs
         id: url
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
           REPO="${{ github.event.repository.name }}"
           ZONE="$(( ${{ github.event.number }} % 50 ))"
-          # Redirect from URL (without -frontend) - will redirect to main
           echo "redirect_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+          echo "frontend_url=https://${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
@@ -57,6 +58,7 @@ jobs:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
+      frontend_url: ${{ needs.vars.outputs.frontend_url }}
       pr_number: ${{ github.event.number }}
 
   results:

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -10,7 +10,7 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: FRONTEND_HOSTNAME
+  - name: HOSTNAME
     description: Frontend hostname, e.g. example.com
     required: true
   - name: TAG
@@ -117,7 +117,7 @@ objects:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: s3-secretkey
                 - name: FRONTEND_URL
-                  value: "https://${FRONTEND_HOSTNAME}"
+                  value: "https://${HOSTNAME}"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: VITE_USER_POOLS_ID

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -10,8 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: FRONTEND_URL
-    description: Full frontend URL, e.g. https://example.com
+  - name: FRONTEND_HOSTNAME
+    description: Frontend hostname, e.g. example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -117,7 +117,7 @@ objects:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: s3-secretkey
                 - name: FRONTEND_URL
-                  value: "${FRONTEND_URL}"
+                  value: "https://${FRONTEND_HOSTNAME}"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: VITE_USER_POOLS_ID

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -16,8 +16,6 @@ parameters:
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
     required: true
-  - name: DOMAIN
-    value: apps.silver.devops.gov.bc.ca
   - name: CPU_REQUEST
     value: "25m"
   - name: MEMORY_REQUEST

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -10,8 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: MOD_ZONE
-    description: Deployment zone, modified for PRs,e.g. pr-### % 50, test or prod
+  - name: FRONTEND_URL
+    description: Full frontend URL, e.g. https://example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -117,7 +117,7 @@ objects:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: s3-secretkey
                 - name: FRONTEND_URL
-                  value: https://${NAME}-${MOD_ZONE}-frontend.${DOMAIN}
+                  value: "${FRONTEND_URL}"
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: VITE_USER_POOLS_ID

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -10,8 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-###, test or prod
     required: true
-  - name: MOD_ZONE
-    description: Deployment zone, modified for PRs,e.g. pr-### % 50, test or prod
+  - name: HOSTNAME
+    description: Hostname for the Route, e.g. example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -101,7 +101,7 @@ objects:
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: URL
-                  value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
+                  value: "https://${HOSTNAME}/"
                 - name: REDIRECT_FROM_HOST
                   value: "${REDIRECT_URL}"
               ports:
@@ -155,7 +155,7 @@ objects:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
-      host: "${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}"
+      host: "${HOSTNAME}"
       port:
         targetPort: 3000-tcp
       to:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -10,8 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-###, test or prod
     required: true
-  - name: FRONTEND_HOSTNAME
-    description: Frontend hostname for the Route, e.g. example.com
+  - name: HOSTNAME
+    description: Hostname for the Route, e.g. example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -101,7 +101,7 @@ objects:
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: URL
-                  value: "https://${FRONTEND_HOSTNAME}/"
+                  value: "https://${HOSTNAME}/"
                 - name: REDIRECT_FROM_HOST
                   value: "${REDIRECT_URL}"
               ports:
@@ -155,7 +155,7 @@ objects:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
-      host: "${FRONTEND_HOSTNAME}"
+      host: "${HOSTNAME}"
       port:
         targetPort: 3000-tcp
       to:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -16,8 +16,6 @@ parameters:
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
     required: true
-  - name: DOMAIN
-    value: apps.silver.devops.gov.bc.ca
   - name: CPU_REQUEST
     value: "25m"
   - name: MEMORY_REQUEST

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -10,8 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-###, test or prod
     required: true
-  - name: HOSTNAME
-    description: Hostname for the Route, e.g. example.com
+  - name: FRONTEND_HOSTNAME
+    description: Frontend hostname for the Route, e.g. example.com
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -101,7 +101,7 @@ objects:
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: URL
-                  value: "https://${HOSTNAME}/"
+                  value: "https://${FRONTEND_HOSTNAME}/"
                 - name: REDIRECT_FROM_HOST
                   value: "${REDIRECT_URL}"
               ports:
@@ -155,7 +155,7 @@ objects:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
-      host: "${HOSTNAME}"
+      host: "${FRONTEND_HOSTNAME}"
       port:
         targetPort: 3000-tcp
       to:


### PR DESCRIPTION
## Description

Replaces `MOD_ZONE` with explicit `hostname` parameter. Hostnames are calculated in `pr-open.yml` and passed as static values in `merge.yml`.

## Changes

- **pr-open.yml**: Calculate `hostname` with MOD_ZONE logic (`PR % 50`), pass directly
- **merge.yml**: Pass static `hostname` values for TEST/PROD
- **.deploy.yml**: Accept `hostname` as required parameter, removed MOD_ZONE calculation entirely
- **Frontend template**: Use `HOSTNAME` parameter, construct URL as `https://${HOSTNAME}/`
- **Backend template**: Use `HOSTNAME` parameter, construct URL as `https://${HOSTNAME}`

## Benefits

1. **Simplicity** - No regex parsing, just pass hostname and add `https://` where needed
2. **Consistency** - Single `hostname` parameter used across both templates
3. **Flexibility** - TEST/PROD can use vanity hostnames via GitHub environment variables
4. **Maintainability** - Matrix includes for clean component-specific parameters

## Related Issue

Fixes #470

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-46-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-46.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-46-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)