### PR TITLE
chore(ci): shai hulud 2 patch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ x-common: &common
 services:
   backend:
     container_name: backend
-    entrypoint: sh -c "npm ci && npm run start"
+    entrypoint: sh -c "npm ci --ignore-scripts && npm run start"
     environment:
       CHES_CLIENT_ID: ${CHES_CLIENT_ID:-09C5071A-ACE9B6FACF6}
       CHES_CLIENT_SECRET: ${CHES_CLIENT_SECRET}
@@ -36,7 +36,7 @@ services:
   frontend:
     container_name: frontend
     profiles: [frontend]
-    entrypoint: sh -c "npm ci && npm run start"
+    entrypoint: sh -c "npm ci --ignore-scripts && npm run start"
     environment:
       VITE_MAIN_VERSION: ${VITE_MAIN_VERSION:-1.0.0}
       VITE_COGNITO_REGION: ${VITE_COGNITO_REGION:-ca-central-1}


### PR DESCRIPTION
The `ci --ignore-scripts` flag prevents pre-loading of npm scripts, which is the primary way Shai Hulud spreads.  This should ideally be used everywhere, although there are exceptions.

Re: [Shai Hulud 2](https://www.sonatype.com/blog/the-second-coming-of-shai-hulud-attackers-innovating-on-npm)
Fix: via @basilv

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-47-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-47.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-47-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)