### PR TITLE
fix: use -frontend URL format for OAuth redirect URI

### DIFF
--- a/frontend/src/amplifyconfiguration.ts
+++ b/frontend/src/amplifyconfiguration.ts
@@ -1,10 +1,44 @@
 import { env } from './env';
 
 const ZONE = (env.VITE_ZONE ?? "DEV").toLocaleLowerCase();
-const redirectUri = window.location.origin;
 const logoutDomain = `https://logon${ZONE === "prod" ? '' : 'test'}7.gov.bc.ca`;
 const returnUrlHost = ZONE === "prod" ? "loginproxy" : ZONE === "test" ? "test.loginproxy" : "dev.loginproxy";
 const retUrl = `https://${returnUrlHost}.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout`;
+
+/**
+ * Constructs the OAuth redirect URI using the -frontend URL format.
+ * Cognito's allowlist includes URLs with the -frontend suffix
+ * (e.g., nr-results-exam-48-frontend.apps.silver.devops.gov.bc.ca).
+ * 
+ * If the user accessed via the redirect-from URL (without -frontend),
+ * we need to add the -frontend suffix to match Cognito's allowlist.
+ */
+const getRedirectSignInUri = (): string => {
+  const origin = window.location.origin;
+  const hostname = window.location.hostname;
+  
+  // Check if hostname does NOT contain -frontend suffix (redirect-from URL format)
+  // e.g., nr-results-exam-48.apps.silver.devops.gov.bc.ca
+  if (!hostname.includes('-frontend.')) {
+    // Add -frontend suffix to match Cognito's allowlist
+    // Insert -frontend before the first dot in the domain part
+    const parts = hostname.split('.');
+    if (parts.length > 0) {
+      const mainHostname = parts[0];
+      const domain = parts.slice(1).join('.');
+      const frontendHostname = `${mainHostname}-frontend.${domain}`;
+      const frontendOrigin = `${window.location.protocol}//${frontendHostname}`;
+      console.log('Using -frontend URL format for OAuth redirect URI:', frontendOrigin);
+      return `${frontendOrigin}/dashboard`;
+    }
+  }
+  
+  // Use current origin if it already has -frontend suffix
+  return `${origin}/dashboard`;
+};
+
+const redirectSignInUri = getRedirectSignInUri();
+const redirectUri = new URL(redirectSignInUri).origin;
 
 const redirectSignOut =
   env.VITE_REDIRECT_SIGN_OUT && env.VITE_REDIRECT_SIGN_OUT.trim() !== ""
@@ -25,7 +59,7 @@ const amplifyconfig = {
         oauth: {
           domain: env.VITE_AWS_DOMAIN || "prod-fam-user-pool-domain.auth.ca-central-1.amazoncognito.com",
           scopes: [ 'openid' ],
-          redirectSignIn: [ `${window.location.origin}/dashboard` ],
+          redirectSignIn: [ redirectSignInUri ],
           redirectSignOut: [ redirectSignOut ],
           responseType: verificationMethods
         }


### PR DESCRIPTION
## Problem

PR #462 added a redirect-from URL (without `-frontend` suffix) that redirects to the main URL (with `-frontend` suffix). Cognito's allowlist includes URLs with the `-frontend` suffix (e.g., `nr-results-exam-48-frontend.apps.silver.devops.gov.bc.ca`).

If a user accesses the app via the redirect-from URL (without `-frontend`), the OAuth redirect URI would not match Cognito's allowlist, causing `redirect_uri_mismatch` errors.

## Solution

This change ensures the OAuth redirect URI always uses the `-frontend` format, even if the user accessed via the redirect-from URL (without `-frontend`). This matches Cognito's allowlist and prevents redirect_uri_mismatch errors.

## Example

- Redirect-from URL: `nr-results-exam-48.apps.silver.devops.gov.bc.ca`
- Main URL: `nr-results-exam-48-frontend.apps.silver.devops.gov.bc.ca`
- OAuth redirect URI: `https://nr-results-exam-48-frontend.apps.silver.devops.gov.bc.ca/dashboard`

## Testing

- [ ] Test login flow when accessing via redirect-from URL (without `-frontend`)
- [ ] Test login flow when accessing via main URL (with `-frontend`)
- [ ] Verify OAuth redirect URI matches Cognito's allowlist

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-2-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-2.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-2-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)