### PR TITLE
feat: replace MOD_ZONE with hostname parameter

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -76,6 +76,16 @@ jobs:
       matrix:
         name: [backend, frontend]
     steps:
+      - name: Set CHES_CLIENT_ID parameter
+        id: ches-client-id
+        if: matrix.name == 'backend'
+        run: |
+          CHES_CLIENT_ID="${{ vars.CHES_CLIENT_ID }}"
+          if [ -z "$CHES_CLIENT_ID" ]; then
+            CHES_CLIENT_ID="09C5071A-ACE9B6FACF6"
+          fi
+          echo "value=$CHES_CLIENT_ID" >> $GITHUB_OUTPUT
+
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
         with:
@@ -86,6 +96,7 @@ jobs:
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
             -p HOSTNAME=${{ inputs.hostname }}
+            ${{ matrix.name == 'backend' && format('-p CHES_CLIENT_ID={0}', steps.ches-client-id.outputs.value) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
 
   smoke:

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -115,7 +115,7 @@ jobs:
     if: failure() && (inputs.zone == 'test' || inputs.zone == 'prod')
     # Create issues for non-PR deployments (test/prod)
     # PRs don't need issues since failures are visible in the PR checks
-    needs: [deploys, smoke]
+    needs: [init, deploys, smoke]
     runs-on: ubuntu-24.04
     permissions:
       issues: write

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -75,6 +75,11 @@ jobs:
     strategy:
       matrix:
         name: [backend, frontend]
+        include:
+          - name: backend
+            parameters: -p CHES_CLIENT_ID=${{ vars.CHES_CLIENT_ID }}
+          - name: frontend
+            parameters: -p REDIRECT_URL=${{ inputs.redirect_url }}
     steps:
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
@@ -86,8 +91,7 @@ jobs:
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
             -p HOSTNAME=${{ inputs.hostname }}
-            ${{ matrix.name == 'backend' && format('-p CHES_CLIENT_ID={0}', vars.CHES_CLIENT_ID) || '' }}
-            ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
+            ${{ matrix.parameters }}
 
   smoke:
     name: Smoke Tests

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -17,6 +17,11 @@ on:
         required: true
         type: string
 
+      hostname:
+        description: Frontend hostname (without protocol), e.g. nr-results-exam-12-frontend.apps.silver.devops.gov.bc.ca
+        required: true
+        type: string
+
       ### Optional
       environment:
         description: GitHub/OpenShift environment; usually PR number, test or prod
@@ -24,10 +29,6 @@ on:
         type: string
       pr_number:
         description: PR number if this is a PR deployment (empty for non-PRs)
-        required: false
-        type: string
-      frontend_url:
-        description: Frontend URL for smoke tests (auto-calculated if not provided)
         required: false
         type: string
 
@@ -50,8 +51,6 @@ jobs:
     timeout-minutes: 1
     permissions:
       contents: read
-    outputs:
-      mod_zone: ${{ steps.mod-zone.outputs.mod_zone }}
     steps:
       - name: Deploy OpenShift init resources
         uses: bcgov/action-deployer-openshift@v4.0.1
@@ -64,17 +63,6 @@ jobs:
             -p CHES_CLIENT_SECRET=${{ secrets.ches_client_secret }}
             -p S3_SECRETKEY=${{ secrets.s3_secretkey }}
             -p VITE_USER_POOLS_WEB_CLIENT_ID=${{ vars.VITE_USER_POOLS_WEB_CLIENT_ID }}
-
-      - name: Calculate MOD_ZONE
-        id: mod-zone
-        run: |
-          # For PR deployments (numeric zones), calculate modulo 50
-          # For named environments (test, prod), use the zone as-is
-          if [[ "${{ inputs.zone }}" =~ ^[0-9]+$ ]]; then
-            echo "mod_zone=$(( ${{ inputs.zone }} % 50 ))" >> $GITHUB_OUTPUT
-          else
-            echo "mod_zone=${{ inputs.zone }}" >> $GITHUB_OUTPUT
-          fi
 
   deploys:
     name: Deploy
@@ -97,7 +85,7 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
-            -p MOD_ZONE=${{ needs.init.outputs.mod_zone }}
+            -p HOSTNAME=${{ inputs.hostname }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
 
   smoke:
@@ -107,20 +95,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - name: Calculate frontend URL
-        id: frontend-url
-        run: |
-          if [ -n "${{ inputs.frontend_url }}" ]; then
-            # Use provided frontend URL
-            echo "url=${{ inputs.frontend_url }}" >> $GITHUB_OUTPUT
-          else
-            # Calculate from zone (for PRs)
-            DOMAIN="apps.silver.devops.gov.bc.ca"
-            REPO="nr-results-exam"
-            MOD_ZONE="${{ needs.init.outputs.mod_zone }}"
-            echo "url=https://${REPO}-${MOD_ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
-          fi
-
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
@@ -130,7 +104,7 @@ jobs:
       - name: Run smoke tests
         working-directory: integration-tests
         env:
-          FRONTEND_URL: ${{ steps.frontend-url.outputs.url }}
+          FRONTEND_URL: https://${{ inputs.hostname }}
           REDIRECT_URL: ${{ inputs.redirect_url && format('https://{0}', inputs.redirect_url) || '' }}
         run: |
           npm ci
@@ -141,7 +115,7 @@ jobs:
     if: failure() && !inputs.pr_number
     # Create issues for non-PR deployments (test/prod)
     # PRs don't need issues since failures are visible in the PR checks
-    needs: [init, deploys, smoke]
+    needs: [deploys, smoke]
     runs-on: ubuntu-24.04
     permissions:
       issues: write

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -27,10 +27,6 @@ on:
         description: GitHub/OpenShift environment; usually PR number, test or prod
         default: ""
         type: string
-      pr_number:
-        description: PR number if this is a PR deployment (empty for non-PRs)
-        required: false
-        type: string
 
     secrets:
       ches_client_secret:
@@ -95,13 +91,12 @@ jobs:
 
   smoke:
     name: Smoke Tests
-    needs: [init, deploys]
+    needs: [deploys]
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -110,7 +105,7 @@ jobs:
         working-directory: integration-tests
         env:
           FRONTEND_URL: https://${{ inputs.hostname }}
-          REDIRECT_URL: ${{ inputs.redirect_url && format('https://{0}', inputs.redirect_url) || '' }}
+          REDIRECT_URL: https://${{ inputs.redirect_url }}
         run: |
           npm ci
           npm run smoke

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -76,16 +76,6 @@ jobs:
       matrix:
         name: [backend, frontend]
     steps:
-      - name: Set CHES_CLIENT_ID parameter
-        id: ches-client-id
-        if: matrix.name == 'backend'
-        run: |
-          CHES_CLIENT_ID="${{ vars.CHES_CLIENT_ID }}"
-          if [ -z "$CHES_CLIENT_ID" ]; then
-            CHES_CLIENT_ID="09C5071A-ACE9B6FACF6"
-          fi
-          echo "value=$CHES_CLIENT_ID" >> $GITHUB_OUTPUT
-
       - uses: bcgov/action-deployer-openshift@v4.0.1
         id: deploys
         with:
@@ -96,7 +86,7 @@ jobs:
           parameters: -p ZONE=${{ inputs.zone }}
             -p TAG=${{ inputs.tag }}
             -p HOSTNAME=${{ inputs.hostname }}
-            ${{ matrix.name == 'backend' && format('-p CHES_CLIENT_ID={0}', steps.ches-client-id.outputs.value) || '' }}
+            ${{ matrix.name == 'backend' && format('-p CHES_CLIENT_ID={0}', vars.CHES_CLIENT_ID) || '' }}
             ${{ matrix.name == 'frontend' && format('-p REDIRECT_URL={0}', inputs.redirect_url) || '' }}
 
   smoke:

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -117,7 +117,7 @@ jobs:
 
   report-failures:
     name: Failure Reporting
-    if: failure() && !inputs.pr_number
+    if: failure() && (inputs.zone == 'test' || inputs.zone == 'prod')
     # Create issues for non-PR deployments (test/prod)
     # PRs don't need issues since failures are visible in the PR checks
     needs: [deploys, smoke]

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -96,7 +96,7 @@ jobs:
             npm run lint
             npm run test:coverage
           dir: ${{ matrix.dir }}
-          node_version: "22"
+          node_version: "24"
           sonar_args: >
             -Dsonar.exclusions=src/__tests__/**,__tests__/**,src/amplifyconfiguration.*,src/**/*.scss,src/**/*.css,src/**/*.d.*,src/setupTests.*
             -Dsonar.organization=bcgov-sonarcloud

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -110,9 +110,10 @@ jobs:
 
   results:
     name: Analysis Results
-    if: always() && !failure()
-    # Include all needs that could have failures!
+    if: always()
     needs: [codeql, trivy, tests]
     runs-on: ubuntu-24.04
     steps:
+      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
+        run: echo "At least one job has failed." && exit 1
       - run: echo "Workflow completed successfully!"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,7 +39,7 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
       redirect_url: results-exam-test.apps.silver.devops.gov.bc.ca
-      frontend_url: https://nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
+      hostname: nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
 
   deploys-prod:
     name: Deploys (PROD)
@@ -54,7 +54,7 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
       redirect_url: results-exam.apps.silver.devops.gov.bc.ca
-      frontend_url: https://nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
+      hostname: nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
 
   image-promotions:
     name: Promote images

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -35,8 +35,9 @@ jobs:
     timeout-minutes: 1
     outputs:
       redirect_url: ${{ steps.url.outputs.redirect_url }}
+      hostname: ${{ steps.url.outputs.hostname }}
     steps:
-      - name: Calculate redirect_url
+      - name: Calculate redirect_url and hostname
         id: url
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
@@ -44,6 +45,8 @@ jobs:
           ZONE="$(( ${{ github.event.number }} % 50 ))"
           # Redirect from URL (without -frontend) - will redirect to main
           echo "redirect_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
+          # Hostname for frontend Route and URLs
+          echo "hostname=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
@@ -57,6 +60,7 @@ jobs:
       tag: ${{ github.event.number }}
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
+      hostname: ${{ needs.vars.outputs.hostname }}
       pr_number: ${{ github.event.number }}
 
   results:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -27,26 +27,22 @@ jobs:
           package: ${{ matrix.package }}
           tags: ${{ github.event.number }}
           tag_fallback: latest
-          triggers: ('${{ matrix.triggers }}/')
 
   vars:
     name: Variables
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     outputs:
-      redirect_url: ${{ steps.url.outputs.redirect_url }}
       hostname: ${{ steps.url.outputs.hostname }}
+      redirect_url: ${{ steps.url.outputs.redirect_url }}
     steps:
       - name: Calculate redirect_url and hostname
         id: url
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
-          REPO="${{ github.event.repository.name }}"
-          ZONE="$(( ${{ github.event.number }} % 50 ))"
-          # Redirect from URL (without -frontend) - will redirect to main
-          echo "redirect_url=${REPO}-${ZONE}.${DOMAIN}" >> $GITHUB_OUTPUT
-          # Hostname for frontend Route and URLs
-          echo "hostname=${REPO}-${ZONE}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          SUBDOMAIN="${{ github.event.repository.name }}-$(( ${{ github.event.number }} % 50 ))"
+          echo "hostname=${SUBDOMAIN}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          echo "redirect_url=${SUBDOMAIN}.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})
@@ -61,14 +57,13 @@ jobs:
       zone: ${{ github.event.number }}
       redirect_url: ${{ needs.vars.outputs.redirect_url }}
       hostname: ${{ needs.vars.outputs.hostname }}
-      pr_number: ${{ github.event.number }}
 
   results:
     name: PR Results
-    if: always() && !failure()
-    # Include all needs that could have failures!
-    # Note: deploys now includes smoke tests
+    if: always()
     needs: [builds, deploys]
     runs-on: ubuntu-24.04
     steps:
+      - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
+        run: echo "At least one job has failed." && exit 1
       - run: echo "Workflow completed successfully!"

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -37,12 +37,6 @@ jobs:
     needs: [validate]
     runs-on: ubuntu-24.04
     steps:
-      - run: |
-          # View results
-          echo "needs.*.result: ${{ toJson(needs.*.result) }}"
-
       - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
-        run: |
-          # Job failure found
-          echo "At least one job has failed"
-          exit 1
+        run: echo "At least one job has failed." && exit 1
+      - run: echo "Workflow completed successfully!"

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -16,8 +16,6 @@ parameters:
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
     required: true
-  - name: DOMAIN
-    value: apps.silver.devops.gov.bc.ca
   - name: CPU_REQUEST
     value: "25m"
   - name: MEMORY_REQUEST
@@ -26,14 +24,6 @@ parameters:
     value: "75m"
   - name: MEMORY_LIMIT
     value: "150Mi"
-  - name: CPU_REQUEST_INIT
-    value: "125m"
-  - name: MEMORY_REQUEST_INIT
-    value: "100Mi"
-  - name: CPU_LIMIT_INIT
-    value: "250m"
-  - name: MEMORY_LIMIT_INIT
-    value: "250Mi"
   - name: MIN_REPLICAS
     description: The minimum amount of replicas for the horizontal pod autoscaler.
     value: "3"
@@ -103,8 +93,6 @@ objects:
                       key: ches-client-secret
                 - name: CHES_TOKEN_URL
                   value: ${CHES_TOKEN_URL}
-                - name: CHES_CLIENT_ID
-                  value: ${CHES_CLIENT_ID}
                 - name: S3_ACCESSKEY
                   value: ${S3_ACCESSKEY}
                 - name: S3_BUCKETNAME

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -10,8 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: MOD_ZONE
-    description: Deployment zone, modified for PRs,e.g. pr-### % 50, test or prod
+  - name: HOSTNAME
+    description: Frontend hostname (without protocol), e.g. nr-results-exam-12-frontend.apps.silver.devops.gov.bc.ca
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -117,7 +117,7 @@ objects:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: s3-secretkey
                 - name: FRONTEND_URL
-                  value: https://${NAME}-${MOD_ZONE}-frontend.${DOMAIN}
+                  value: https://${HOSTNAME}
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: VITE_USER_POOLS_ID

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -99,7 +99,7 @@ objects:
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: URL
-                  value: "https://${HOSTNAME}/"
+                  value: "https://${HOSTNAME}"
                 - name: REDIRECT_FROM_HOST
                   value: "${REDIRECT_URL}"
               ports:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -10,8 +10,8 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-###, test or prod
     required: true
-  - name: MOD_ZONE
-    description: Deployment zone, modified for PRs,e.g. pr-### % 50, test or prod
+  - name: HOSTNAME
+    description: Frontend hostname (without protocol), e.g. nr-results-exam-12-frontend.apps.silver.devops.gov.bc.ca
     required: true
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
@@ -101,7 +101,7 @@ objects:
                 - name: RANDOM_EXPRESSION
                   value: ${RANDOM_EXPRESSION}
                 - name: URL
-                  value: "https://${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}/"
+                  value: "https://${HOSTNAME}/"
                 - name: REDIRECT_FROM_HOST
                   value: "${REDIRECT_URL}"
               ports:
@@ -155,7 +155,7 @@ objects:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
-      host: "${NAME}-${MOD_ZONE}-${COMPONENT}.${DOMAIN}"
+      host: "${HOSTNAME}"
       port:
         targetPort: 3000-tcp
       to:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -16,8 +16,6 @@ parameters:
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
     required: true
-  - name: DOMAIN
-    value: apps.silver.devops.gov.bc.ca
   - name: CPU_REQUEST
     value: "25m"
   - name: MEMORY_REQUEST


### PR DESCRIPTION
Replaces `MOD_ZONE` calculation with explicit `hostname` parameter across all deployment workflows. This simplifies the deployment process by removing the modulo calculation step and making hostnames explicit.

## Changes

### Workflow Updates
* **pr-open.yml**: Calculate `hostname` with MOD_ZONE logic (`PR % 50`) inline, pass directly to deploy workflow
* **merge.yml**: Pass static `hostname` values for TEST/PROD environments
* **.deploy.yml**: 
  - Accept `hostname` as required input parameter
  - Removed MOD_ZONE calculation step entirely (simplified `init` job)
  - Removed unused `pr_number` and `frontend_url` inputs
  - Updated smoke tests to use `hostname` input directly
  - Improved matrix strategy to pass component-specific parameters (CHES_CLIENT_ID for backend, REDIRECT_URL for frontend)

### Template Updates
* **Frontend template**: Use `HOSTNAME` parameter directly, construct URL as `https://${HOSTNAME}`
* **Backend template**: Use `HOSTNAME` parameter, construct `FRONTEND_URL` as `https://${HOSTNAME}`
* **Template cleanup**: Removed unused `DOMAIN` parameter from both templates
* **Template cleanup**: Removed unused INIT resource parameters from backend template
* **Bug fix**: Removed duplicate `CHES_CLIENT_ID` environment variable in backend template

## Benefits

1. **Simplicity** - No regex parsing or modulo calculations in deploy workflow, just pass hostname and add `https://` where needed
2. **Consistency** - Single `hostname` parameter used across both templates
3. **Flexibility** - TEST/PROD can use vanity hostnames via GitHub environment variables
4. **Maintainability** - Cleaner workflow without MOD_ZONE calculation step, removed unused template parameters
5. **Clarity** - Explicit hostnames make deployments easier to understand and debug

## Related Issue

Fixes #470

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-5-frontend.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-5.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-5-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)