### PR TITLE
chore: CI shorten URLs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -38,8 +38,8 @@ jobs:
       environment: test
       tag: ${{ needs.vars.outputs.pr }}
       zone: test
-      redirect_url: results-exam-test.apps.silver.devops.gov.bc.ca
-      hostname: nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
+      hostname: results-exam-test.apps.silver.devops.gov.bc.ca
+      redirect_url: nr-results-exam-test-frontend.apps.silver.devops.gov.bc.ca
 
   deploys-prod:
     name: Deploys (PROD)
@@ -53,8 +53,8 @@ jobs:
       environment: prod
       tag: ${{ needs.vars.outputs.pr }}
       zone: prod
-      redirect_url: results-exam.apps.silver.devops.gov.bc.ca
-      hostname: nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
+      hostname: results-exam.apps.silver.devops.gov.bc.ca
+      redirect_url: nr-results-exam-prod-frontend.apps.silver.devops.gov.bc.ca
 
   image-promotions:
     name: Promote images

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -41,8 +41,8 @@ jobs:
         run: |
           DOMAIN="apps.silver.devops.gov.bc.ca"
           SUBDOMAIN="${{ github.event.repository.name }}-$(( ${{ github.event.number }} % 50 ))"
-          echo "hostname=${SUBDOMAIN}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
-          echo "redirect_url=${SUBDOMAIN}.${DOMAIN}" >> $GITHUB_OUTPUT
+          echo "redirect_url=${SUBDOMAIN}-frontend.${DOMAIN}" >> $GITHUB_OUTPUT
+          echo "hostname=${SUBDOMAIN}.${DOMAIN}" >> $GITHUB_OUTPUT
 
   deploys:
     name: Deploys (${{ github.event.number }})

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -27,8 +27,8 @@ jobs:
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@v1.0.0
     with:
       markdown_links: |
-        - [Frontend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}-frontend.apps.silver.devops.gov.bc.ca)
-        - [Redirect](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}.apps.silver.devops.gov.bc.ca)
+        - [Frontend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}.apps.silver.devops.gov.bc.ca)
+        - [Redirect](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}-frontend.apps.silver.devops.gov.bc.ca)
         - [Backend](https://${{ github.event.repository.name }}-${{ needs.init.outputs.mod-tag }}-frontend.apps.silver.devops.gov.bc.ca/health)
 
   results:


### PR DESCRIPTION
Shorter variables are already loaded as `redirect_url`.  This PR swaps that var with `hostname`, making the shorter URLs the default URLs.

We had to test our changes before asking for changes in FAM, which have now happened.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-19.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-19-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-19-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)