### PR TITLE
fix: ZAP scan configuration errors

### DIFF
--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.13.0
         with:

--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -14,7 +14,7 @@ jobs:
     name: ZAP Tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.13.0

--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -13,15 +13,18 @@ jobs:
     runs-on: ubuntu-24.04
     name: ZAP Tests
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.13.0
         with:
           allow_issue_writing: true
           artifact_name: "zap"
-          # -l MEDIUM: Only report Medium and High risk alerts (ignore Low/Informational)
-          # -J: Generate JSON report for artifact analysis
+          # -l WARN: Only report WARN and FAIL level alerts (Medium/High risk)
           # -a: Include all alerts in reports (for artifact analysis)
-          cmd_options: "-l MEDIUM -J -a"
+          # Note: -J is added automatically by the action, don't duplicate it
+          cmd_options: "-l WARN -a"
           rules_file_name: ".zap/rules.tsv"
           issue_title: "ZAP Penetration Test"
           target: "https://results-exam-test.apps.silver.devops.gov.bc.ca"


### PR DESCRIPTION
## Problem

ZAP scan failing with two errors:
1. `ENOENT: no such file or directory, open '.zap/rules.tsv'` - Rules file not found
2. `Level must be one of ['PASS', 'IGNORE', 'INFO', 'WARN', 'FAIL']` - Invalid level 'MEDIUM'

## Solution

- ✅ Add `checkout@v4` step to ensure `.zap/rules.tsv` is available
- ✅ Fix `cmd_options`: Change `-l MEDIUM` to `-l WARN` (correct ZAP level format)
- ✅ Remove duplicate `-J` flag (action adds it automatically)

## Changes

- Added checkout step before ZAP scan
- Changed `-l MEDIUM` to `-l WARN` (WARN = Medium/High risk alerts)
- Removed duplicate `-J` from cmd_options

## Testing

After merge, next ZAP scan should:
- Find the rules file correctly
- Use correct level format (WARN)
- Successfully filter documented alerts
- Focus on actionable Medium/High risk findings

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-29.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-29-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-29-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)