### PR TITLE
feat: access request form link for passing users

### DIFF
--- a/frontend/src/__tests__/services/EmailService.test.ts
+++ b/frontend/src/__tests__/services/EmailService.test.ts
@@ -46,6 +46,22 @@ describe('EmailService', () => {
 
       expect(result).toBe('error');
     });
+
+    it('should include online access request form link in email body', async () => {
+      mockedAxios.post.mockResolvedValueOnce({ data: 'success' });
+
+      await sendUserReport('John Doe', 'john@example.com', 75, 'Test A');
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        '/api/mail',
+        expect.objectContaining({
+          mailBody: expect.stringContaining(
+            'https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp',
+          ),
+        }),
+        expect.objectContaining({}),
+      );
+    });
   });
 
   describe('sendAdminReport', () => {

--- a/frontend/src/__tests__/services/EmailService.test.ts
+++ b/frontend/src/__tests__/services/EmailService.test.ts
@@ -47,7 +47,7 @@ describe('EmailService', () => {
       expect(result).toBe('error');
     });
 
-    it('should include online access request form link in email body', async () => {
+    it('should include online access request form link for passing users', async () => {
       mockedAxios.post.mockResolvedValueOnce({ data: 'success' });
 
       await sendUserReport('John Doe', 'john@example.com', 75, 'Test A');
@@ -56,6 +56,22 @@ describe('EmailService', () => {
         '/api/mail',
         expect.objectContaining({
           mailBody: expect.stringContaining(
+            'https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp',
+          ),
+        }),
+        expect.objectContaining({}),
+      );
+    });
+
+    it('should not include online access request form link for failing users', async () => {
+      mockedAxios.post.mockResolvedValueOnce({ data: 'success' });
+
+      await sendUserReport('John Doe', 'john@example.com', 40, 'Test A');
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        '/api/mail',
+        expect.objectContaining({
+          mailBody: expect.not.stringContaining(
             'https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp',
           ),
         }),

--- a/frontend/src/__tests__/services/EmailService.test.ts
+++ b/frontend/src/__tests__/services/EmailService.test.ts
@@ -68,14 +68,10 @@ describe('EmailService', () => {
 
       await sendUserReport('John Doe', 'john@example.com', 40, 'Test A');
 
-      expect(mockedAxios.post).toHaveBeenCalledWith(
-        '/api/mail',
-        expect.objectContaining({
-          mailBody: expect.not.stringContaining(
-            'https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp',
-          ),
-        }),
-        expect.objectContaining({}),
+      expect(mockedAxios.post).toHaveBeenCalled();
+      const [, payload] = mockedAxios.post.mock.calls[0];
+      expect(payload.mailBody).not.toContain(
+        'https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp',
       );
     });
   });

--- a/frontend/src/services/EmailService.ts
+++ b/frontend/src/services/EmailService.ts
@@ -37,6 +37,7 @@ export const sendUserReport = async (
           <p class="result">
             ${passOrFail === 'Passed' ? 'Congratulations! You have passed the test' : 'Sorry! You have failed the test'} with a percentage of ${percentage} %.
           </p>
+          ${passOrFail === 'Failed' ? '<p>To continue the access request process, please go to the <a href="https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp">Online access request form</a>.</p>' : ''}
           <p>Please do not reply to this email. If you have successfully passed the test, someone from the team will be reaching out to you with next steps.</p>
           <p>Regards,<br>RESULTS Bot</p>
         </div>

--- a/frontend/src/services/EmailService.ts
+++ b/frontend/src/services/EmailService.ts
@@ -37,7 +37,7 @@ export const sendUserReport = async (
           <p class="result">
             ${passOrFail === 'Passed' ? 'Congratulations! You have passed the test' : 'Sorry! You have failed the test'} with a percentage of ${percentage} %.
           </p>
-          ${passOrFail === 'Failed' ? '<p>To continue the access request process, please go to the <a href="https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp">Online access request form</a>.</p>' : ''}
+          <p>To continue the access request process, please go to the <a href="https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp">Online access request form</a>.</p>
           <p>Please do not reply to this email. If you have successfully passed the test, someone from the team will be reaching out to you with next steps.</p>
           <p>Regards,<br>RESULTS Bot</p>
         </div>

--- a/frontend/src/services/EmailService.ts
+++ b/frontend/src/services/EmailService.ts
@@ -38,7 +38,7 @@ export const sendUserReport = async (
             ${passOrFail === 'Passed' ? 'Congratulations! You have passed the test' : 'Sorry! You have failed the test'} with a percentage of ${percentage} %.
           </p>
           ${passOrFail === 'Passed' ? '<p>To continue the access request process, please go to the <a href="https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp">Online access request form</a>.</p>' : ''}
-          ${passOrFail === 'Failed' ? '<p>Without a passing score, unfortunately you cannot proceed any further. Please try the test again when you are ready.  For further information pleas contact RESULTSAccess@gov.bc.ca.</p>' : ''}
+          ${passOrFail === 'Failed' ? '<p>Without a passing score, unfortunately you cannot proceed any further. Please try the test again when you are ready.  For further information please contact RESULTSAccess@gov.bc.ca.</p>' : ''}
           <p>Please do not reply to this email.</p>
           <p>Regards,<br>RESULTS Bot</p>
         </div>

--- a/frontend/src/services/EmailService.ts
+++ b/frontend/src/services/EmailService.ts
@@ -37,7 +37,7 @@ export const sendUserReport = async (
           <p class="result">
             ${passOrFail === 'Passed' ? 'Congratulations! You have passed the test' : 'Sorry! You have failed the test'} with a percentage of ${percentage} %.
           </p>
-          <p>To continue the access request process, please go to the <a href="https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp">Online access request form</a>.</p>
+          ${passOrFail === 'Passed' ? '<p>To continue the access request process, please go to the <a href="https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp">Online access request form</a>.</p>' : ''}
           <p>Please do not reply to this email. If you have successfully passed the test, someone from the team will be reaching out to you with next steps.</p>
           <p>Regards,<br>RESULTS Bot</p>
         </div>

--- a/frontend/src/services/EmailService.ts
+++ b/frontend/src/services/EmailService.ts
@@ -38,7 +38,7 @@ export const sendUserReport = async (
             ${passOrFail === 'Passed' ? 'Congratulations! You have passed the test' : 'Sorry! You have failed the test'} with a percentage of ${percentage} %.
           </p>
           ${passOrFail === 'Passed' ? '<p>To continue the access request process, please go to the <a href="https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp">Online access request form</a>.</p>' : ''}
-          ${passOrFail === 'Failed' ? '<p>Without a passing score we unfortunately cannot proceed any further.  Please try the test again when you are ready. Contact RESULTSAccess@gov.bc.ca for more information.</p>' : ''}
+          ${passOrFail === 'Failed' ? '<p>Without a passing score, unfortunately you cannot proceed any further. Please try the test again when you are ready.  For further information pleas contact RESULTSAccess@gov.bc.ca.</p>' : ''}
           <p>Please do not reply to this email.</p>
           <p>Regards,<br>RESULTS Bot</p>
         </div>

--- a/frontend/src/services/EmailService.ts
+++ b/frontend/src/services/EmailService.ts
@@ -38,7 +38,8 @@ export const sendUserReport = async (
             ${passOrFail === 'Passed' ? 'Congratulations! You have passed the test' : 'Sorry! You have failed the test'} with a percentage of ${percentage} %.
           </p>
           ${passOrFail === 'Passed' ? '<p>To continue the access request process, please go to the <a href="https://extranet.for.gov.bc.ca/escripts/efm/access/results/access.asp">Online access request form</a>.</p>' : ''}
-          <p>Please do not reply to this email. If you have successfully passed the test, someone from the team will be reaching out to you with next steps.</p>
+          ${passOrFail === 'Failed' ? '<p>Without a passing score we unfortunately cannot proceed any further.  Please try the test again when you are ready. Contact RESULTSAccess@gov.bc.ca for more information.</p>' : ''}
+          <p>Please do not reply to this email.</p>
           <p>Regards,<br>RESULTS Bot</p>
         </div>
       </body>


### PR DESCRIPTION
## Summary
- Adds a link to the Online access request form in the email sent to users who pass the test
- The link directs users to continue the access request process at the extranet form
- Only displays for users who pass the test (not shown for failing users)

## Test plan
- [ ] Verify email template renders correctly for passing test results
- [ ] Confirm the link appears only when the user has passed
- [ ] Verify failing users do not see the additional link

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-17.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-17-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-17-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)