### PR TITLE
chore(ci): migrate Trivy scanners flag to 'misconfig'

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -43,7 +43,7 @@ jobs:
           output: "trivy-results.sarif"
           ignore-unfixed: true
           scan-type: "fs"
-          scanners: "vuln,secret,config"
+          scanners: "vuln,secret,misconfig"
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Updates deprecated '--scanners config' to '--scanners misconfig' to align with updated standards.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-21.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-21-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-21-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)