### PR TITLE
chore(deps): upgrade typescript to v6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "jsdom": "^29.0.0",
         "prettier": "^3.7.4",
         "sass": "^1.75.0",
-        "typescript": "^5.4.5",
+        "typescript": "^6.0.0",
         "vitest": "^4.0.0"
       }
     },
@@ -1606,9 +1606,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1687,9 +1687,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5090,9 +5090,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5161,9 +5161,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8707,9 +8707,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,13 +61,10 @@
     "jsdom": "^29.0.0",
     "prettier": "^3.7.4",
     "sass": "^1.75.0",
-    "typescript": "^5.4.5",
+    "typescript": "^6.0.0",
     "vitest": "^4.0.0"
   },
   "overrides": {
-    "minimatch@3.x": {
-      "brace-expansion": "1.1.12"
-    },
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "@types/react": "^19.2.2",

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -38,7 +38,7 @@ export const getAuthIdToken = () => {
  */
 export const parseToken = (idToken: JWT | undefined): FamLoginUser | undefined => {
   if (!idToken) return undefined;
-  setAuthIdToken(idToken?.toString() || null);
+  setAuthIdToken(idToken?.toString?.() || null);
   const decodedIdToken = idToken?.payload;
 
   const displayName = (decodedIdToken?.['custom:idp_display_name'] as string) || '';

--- a/frontend/src/types/amplify.ts
+++ b/frontend/src/types/amplify.ts
@@ -1,6 +1,7 @@
 // src/types/amplify.ts
-import type { JWT as AmplifyJWT } from '@aws-amplify/core/dist/esm/singleton/Auth/types';
-
-export type JWT = AmplifyJWT;
+export interface JWT {
+  toString(): string;
+  payload: Record<string, any>;
+}
 
 export type ProviderType = 'idir' | 'bceid';

--- a/frontend/src/types/amplify.ts
+++ b/frontend/src/types/amplify.ts
@@ -1,7 +1,7 @@
 // src/types/amplify.ts
 export interface JWT {
-  toString(): string;
-  payload: Record<string, any>;
+  toString?(): string;
+  payload: Record<string, unknown>;
 }
 
 export type ProviderType = 'idir' | 'bceid';

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,7 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
Bumps TypeScript to ^6.0.0, deletes redundant brace-expansion overrides, and migrates the deprecated moduleResolution option in tsconfig.json to the modern, standard "bundler" resolution. Also resolved the Amplify deep-import issue that breaks under bundler resolution mode.

Closes #604

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-20.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-20-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-20-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)