### PR TITLE
chore(deps): remove obsolete minimatch override

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,9 +64,6 @@
     "vitest": "^4.0.0"
   },
   "overrides": {
-    "minimatch@3.x": {
-      "brace-expansion": "1.1.15"
-    },
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "@types/react": "^19.2.2",


### PR DESCRIPTION
This PR removes the obsolete minimatch override that was causing Renovate to generate broken lockfiles. Closes #632

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-33.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-33-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-33-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)