### PR TITLE
fix(smoke): increase default timeout to 15s to prevent cold-start failures

### DIFF
--- a/tests/src/smoke.js
+++ b/tests/src/smoke.js
@@ -3,7 +3,7 @@ import axios from "axios";
 const frontendUrl = process.env.FRONTEND_URL?.replace(/\/$/, "") ?? "http://localhost:3000";
 const redirectFromUrl = process.env.REDIRECT_URL?.replace(/\/$/, "");
 const origin = process.env.SMOKE_ORIGIN ?? frontendUrl;
-const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_TIMEOUT_MS = 15000;
 const MIN_TIMEOUT_MS = 1000;
 
 const timeoutMs = (() => {


### PR DESCRIPTION
---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-results-exam-40.apps.silver.devops.gov.bc.ca)
- [Redirect](https://nr-results-exam-40-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-results-exam-40-frontend.apps.silver.devops.gov.bc.ca/health)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-results-exam/actions/workflows/merge.yml)